### PR TITLE
fix: use fileURLToPath for prompt.md path resolution

### DIFF
--- a/playwriter/src/mcp.ts
+++ b/playwriter/src/mcp.ts
@@ -6,6 +6,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { spawn } from 'node:child_process'
 import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
 import vm from 'node:vm'
 import dedent from 'string-dedent'
 import { createPatch } from 'diff'
@@ -328,7 +329,7 @@ const server = new McpServer({
   version: '1.0.0',
 })
 
-const promptContent = fs.readFileSync(path.join(path.dirname(new URL(import.meta.url).pathname), 'prompt.md'), 'utf-8')
+const promptContent = fs.readFileSync(path.join(path.dirname(fileURLToPath(import.meta.url)), 'prompt.md'), 'utf-8')
 
 server.tool(
   'execute',
@@ -665,3 +666,4 @@ async function main() {
 }
 
 main().catch(console.error)
+


### PR DESCRIPTION
## Summary

- Use `fileURLToPath` to correctly resolve `prompt.md` path on Windows.
- Fixes issue where `pathname` returns a leading slash on Windows (e.g. `/C:/...`) causing file read errors.
