### PR TITLE
feat: add Claude Code plugin marketplace configuration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,39 +1,19 @@
 {
-  "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/.claude-plugin/marketplace-schema.json",
   "name": "playwriter",
-  "displayName": "Playwriter",
-  "description": "Browser automation MCP via Chrome extension. Control your browser with full Playwright API - 80% less context window than alternatives.",
-  "publisher": "remorses",
-  "repository": "https://github.com/remorses/playwriter",
-  "license": "MIT",
+  "owner": {
+    "name": "Tommy D. Rossi",
+    "email": "tommy@notaku.so"
+  },
   "plugins": [
     {
       "name": "playwriter",
-      "displayName": "Playwriter",
-      "description": "Control Chrome tabs with full Playwright API via extension. Features accessibility snapshots, visual labels, debugger access, and more.",
-      "mcpServers": {
-        "playwriter": {
-          "command": "npx",
-          "args": ["playwriter@latest"]
-        }
-      },
-      "userConfig": {
-        "host": {
-          "type": "string",
-          "description": "Remote host for the Playwriter server (e.g., host.docker.internal for devcontainers)",
-          "required": false
-        },
-        "token": {
-          "type": "string",
-          "description": "Authentication token for remote connections",
-          "required": false
-        },
-        "autoEnable": {
-          "type": "boolean",
-          "description": "Automatically create an initial tab when connecting",
-          "required": false
-        }
-      }
+      "source": "./playwriter",
+      "description": "Browser automation MCP via Chrome extension. Control your browser with full Playwright API.",
+      "keywords": ["browser", "playwright", "automation", "chrome", "mcp"]
     }
-  ]
+  ],
+  "metadata": {
+    "description": "Playwriter - Browser automation plugin for Claude Code",
+    "version": "1.0.0"
+  }
 }

--- a/playwriter/.claude-plugin/plugin.json
+++ b/playwriter/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "playwriter",
+  "description": "Control Chrome tabs with full Playwright API via extension. Features accessibility snapshots, visual labels, debugger access, and more.",
+  "author": {
+    "name": "Tommy D. Rossi",
+    "email": "tommy@notaku.so"
+  }
+}

--- a/playwriter/.mcp.json
+++ b/playwriter/.mcp.json
@@ -1,0 +1,6 @@
+{
+  "playwriter": {
+    "command": "npx",
+    "args": ["playwriter@latest"]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds Claude Code plugin configuration for Playwriter
- Allows users to install Playwriter directly via `/plugins` in Claude Code
- Properly structured with `marketplace.json`, `plugin.json`, and `.mcp.json`

## What This Enables

Once merged, Claude Code users can:

1. **Add the repo as a marketplace source** in their `~/.claude/settings.json`:
```json
{
  "extraKnownMarketplaces": {
    "playwriter": {
      "source": {
        "source": "github",
        "repo": "remorses/playwriter"
      }
    }
  }
}
```

2. **Enable the plugin** via Claude Code's `/plugins` UI or in settings:
```json
{
  "enabledPlugins": {
    "playwriter@playwriter": true
  }
}
```

## Plugin Structure

```
.claude-plugin/
└── marketplace.json    # Marketplace metadata & plugin registry

playwriter/
├── .claude-plugin/
│   └── plugin.json     # Plugin metadata (name, description, author)
└── .mcp.json           # MCP server configuration
```

## Test plan
- [x] Verify marketplace.json validates against Claude Code's schema
- [x] Test enabling the plugin in a Claude Code project
- [ ] Verify MCP server starts correctly when plugin is enabled

---

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)