### PR TITLE
Add configurable relay endpoint for extension

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "Playwriter",
   "version": "0.0.71",
   "description": "Automate your Browser using Cursor, Claude, VS Code. More capable and context efficient than Playwright MCP.",
-  "permissions": ["debugger", "tabGroups", "contextMenus", "tabs", "tabCapture", "offscreen", "identity", "identity.email"],
+  "permissions": ["debugger", "tabGroups", "contextMenus", "tabs", "tabCapture", "offscreen", "identity", "identity.email", "storage"],
   "host_permissions": ["<all_urls>"],
   "background": {
     "service_worker": "background.js",
@@ -18,6 +18,7 @@
       "128": "icons/icon-gray-128.png"
     }
   },
+  "options_page": "src/options.html",
   "icons": {
     "16": "icons/icon-gray-16.png",
     "32": "icons/icon-gray-32.png",

--- a/extension/src/options.html
+++ b/extension/src/options.html
@@ -1,0 +1,157 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Playwriter Options</title>
+    <style>
+      :root {
+        --bg: #0b1020;
+        --panel: #111832;
+        --text: #e7ecff;
+        --muted: #9fb0e8;
+        --border: #2a396f;
+        --accent: #79a8ff;
+        --success: #5ad8a6;
+        --error: #ff8f8f;
+      }
+
+      @media (prefers-color-scheme: light) {
+        :root {
+          --bg: #f4f7ff;
+          --panel: #ffffff;
+          --text: #0f1a3b;
+          --muted: #50608f;
+          --border: #c9d7ff;
+          --accent: #245fff;
+          --success: #147d56;
+          --error: #b42318;
+        }
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+        padding: 32px 20px;
+      }
+
+      main {
+        max-width: 720px;
+        margin: 0 auto;
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        padding: 24px;
+      }
+
+      h1 {
+        margin: 0 0 8px;
+        font-size: 1.35rem;
+      }
+
+      p {
+        margin: 0 0 16px;
+        color: var(--muted);
+      }
+
+      .row {
+        display: grid;
+        grid-template-columns: 140px 1fr;
+        gap: 12px;
+        align-items: center;
+        margin-bottom: 12px;
+      }
+
+      label {
+        font-weight: 600;
+      }
+
+      input {
+        width: 100%;
+        padding: 10px 12px;
+        border-radius: 10px;
+        border: 1px solid var(--border);
+        background: transparent;
+        color: var(--text);
+      }
+
+      .actions {
+        margin-top: 20px;
+        display: flex;
+        gap: 10px;
+      }
+
+      button {
+        border-radius: 10px;
+        border: 1px solid var(--border);
+        padding: 10px 14px;
+        background: transparent;
+        color: var(--text);
+        cursor: pointer;
+      }
+
+      button[type='submit'] {
+        background: var(--accent);
+        border-color: var(--accent);
+        color: #fff;
+      }
+
+      #status[data-kind='success'] {
+        color: var(--success);
+      }
+
+      #status[data-kind='error'] {
+        color: var(--error);
+      }
+
+      code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Playwriter Relay Settings</h1>
+      <p>
+        Configure where the extension should connect. This is useful when your relay is not on
+        <code>127.0.0.1:19988</code> (for example, Tailscale or custom port setups).
+      </p>
+      <p>
+        If using a remote relay, start it with <code>playwriter serve --allow-remote-extension --token ...</code>
+        and set the same token here.
+      </p>
+
+      <form id="relay-form">
+        <div class="row">
+          <label for="relay-host">Relay host</label>
+          <input id="relay-host" name="relay-host" placeholder="127.0.0.1" required />
+        </div>
+
+        <div class="row">
+          <label for="relay-port">Relay port</label>
+          <input id="relay-port" name="relay-port" type="number" min="1" max="65535" required />
+        </div>
+
+        <div class="row">
+          <label for="relay-token">Relay token</label>
+          <input id="relay-token" name="relay-token" type="password" placeholder="optional" />
+        </div>
+
+        <div class="actions">
+          <button type="submit">Save</button>
+          <button type="button" id="reset-defaults">Reset defaults</button>
+        </div>
+      </form>
+
+      <p id="status" data-kind="success"></p>
+    </main>
+
+    <script type="module" src="./options.ts"></script>
+  </body>
+</html>

--- a/extension/src/options.ts
+++ b/extension/src/options.ts
@@ -1,0 +1,62 @@
+import {
+  DEFAULT_RELAY_HOST,
+  DEFAULT_RELAY_PORT,
+  getRelayConfig,
+  normalizeRelayConfig,
+  setRelayConfig,
+} from './relay-config'
+
+function requireElement<T extends Element>(selector: string): T {
+  const element = document.querySelector<T>(selector)
+  if (!element) {
+    throw new Error(`Missing options form element: ${selector}`)
+  }
+  return element
+}
+
+const hostInput = requireElement<HTMLInputElement>('#relay-host')
+const portInput = requireElement<HTMLInputElement>('#relay-port')
+const tokenInput = requireElement<HTMLInputElement>('#relay-token')
+const statusEl = requireElement<HTMLParagraphElement>('#status')
+const form = requireElement<HTMLFormElement>('#relay-form')
+const resetButton = requireElement<HTMLButtonElement>('#reset-defaults')
+
+function setStatus(message: string, kind: 'success' | 'error' = 'success'): void {
+  statusEl.textContent = message
+  statusEl.dataset.kind = kind
+}
+
+async function populateForm(): Promise<void> {
+  const relayConfig = await getRelayConfig()
+  hostInput.value = relayConfig.host
+  portInput.value = String(relayConfig.port)
+  tokenInput.value = relayConfig.token || ''
+}
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault()
+
+  const config = normalizeRelayConfig({
+    host: hostInput.value,
+    port: portInput.value,
+    token: tokenInput.value,
+  })
+
+  await setRelayConfig(config)
+  hostInput.value = config.host
+  portInput.value = String(config.port)
+  tokenInput.value = config.token || ''
+  setStatus(`Saved. Relay endpoint is ${config.host}:${config.port}.`)
+})
+
+resetButton.addEventListener('click', async () => {
+  await setRelayConfig({ host: DEFAULT_RELAY_HOST, port: DEFAULT_RELAY_PORT, token: undefined })
+  hostInput.value = DEFAULT_RELAY_HOST
+  portInput.value = String(DEFAULT_RELAY_PORT)
+  tokenInput.value = ''
+  setStatus(`Reset to defaults (${DEFAULT_RELAY_HOST}:${DEFAULT_RELAY_PORT}).`)
+})
+
+void populateForm().catch((error) => {
+  setStatus(`Failed to load settings: ${(error as Error).message}`, 'error')
+})

--- a/extension/src/relay-config.ts
+++ b/extension/src/relay-config.ts
@@ -1,0 +1,55 @@
+declare const process: { env: { PLAYWRITER_PORT?: string } }
+
+export type RelayConfig = {
+  host: string
+  port: number
+  token?: string
+}
+
+export const RELAY_CONFIG_STORAGE_KEY = 'relayConfig'
+export const DEFAULT_RELAY_HOST = '127.0.0.1'
+export const DEFAULT_RELAY_PORT = Number(process.env.PLAYWRITER_PORT) || 19988
+
+function normalizeHost(value: unknown): string {
+  if (typeof value !== 'string') return DEFAULT_RELAY_HOST
+  const host = value.trim()
+  return host || DEFAULT_RELAY_HOST
+}
+
+function normalizePort(value: unknown): number {
+  if (typeof value !== 'string' && typeof value !== 'number') return DEFAULT_RELAY_PORT
+  const port = Number(value)
+  if (!Number.isInteger(port)) return DEFAULT_RELAY_PORT
+  if (port < 1 || port > 65535) return DEFAULT_RELAY_PORT
+  return port
+}
+
+function normalizeToken(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const token = value.trim()
+  return token || undefined
+}
+
+export function normalizeRelayConfig(value: unknown): RelayConfig {
+  if (!value || typeof value !== 'object') {
+    return { host: DEFAULT_RELAY_HOST, port: DEFAULT_RELAY_PORT }
+  }
+
+  const record = value as { host?: unknown; port?: unknown; token?: unknown }
+  return {
+    host: normalizeHost(record.host),
+    port: normalizePort(record.port),
+    token: normalizeToken(record.token),
+  }
+}
+
+export async function getRelayConfig(): Promise<RelayConfig> {
+  const stored = await chrome.storage.local.get(RELAY_CONFIG_STORAGE_KEY)
+  return normalizeRelayConfig(stored[RELAY_CONFIG_STORAGE_KEY])
+}
+
+export async function setRelayConfig(config: RelayConfig): Promise<void> {
+  await chrome.storage.local.set({
+    [RELAY_CONFIG_STORAGE_KEY]: normalizeRelayConfig(config),
+  })
+}

--- a/extension/vite.config.mts
+++ b/extension/vite.config.mts
@@ -68,6 +68,7 @@ export default defineConfig({
       input: {
         background: resolve(__dirname, 'src/background.ts'),
         offscreen: resolve(__dirname, 'src/offscreen.html'),
+        options: resolve(__dirname, 'src/options.html'),
         welcome: resolve(__dirname, 'src/welcome.html'),
       },
       output: {

--- a/playwriter/src/cli.ts
+++ b/playwriter/src/cli.ts
@@ -422,8 +422,9 @@ cli
   .command('serve', 'Start the CDP relay server for remote MCP connections')
   .option('--host <host>', 'Host to bind to', { default: '0.0.0.0' })
   .option('--token <token>', 'Authentication token (or use PLAYWRITER_TOKEN env var)')
+  .option('--allow-remote-extension', 'Allow extension connections from non-localhost IPs (requires token)')
   .option('--replace', 'Kill existing server if running')
-  .action(async (options: { host: string; token?: string; replace?: boolean }) => {
+  .action(async (options: { host: string; token?: string; allowRemoteExtension?: boolean; replace?: boolean }) => {
     const token = options.token || process.env.PLAYWRITER_TOKEN
     const isPublicHost = options.host === '0.0.0.0' || options.host === '::'
     if (isPublicHost && !token) {
@@ -485,6 +486,7 @@ cli
       port: RELAY_PORT,
       host: options.host,
       token,
+      allowRemoteExtension: Boolean(options.allowRemoteExtension),
       logger,
     })
 
@@ -492,6 +494,7 @@ cli
     console.log(`  Host: ${options.host}`)
     console.log(`  Port: ${RELAY_PORT}`)
     console.log(`  Token: ${token ? '(configured)' : '(none)'}`)
+    console.log(`  Remote extension: ${options.allowRemoteExtension ? 'enabled' : 'disabled'}`)
     console.log(`  Logs: ${logger.logFilePath}`)
     console.log(`  CDP Logs: ${LOG_CDP_FILE_PATH}`)
     console.log('')


### PR DESCRIPTION
**Summary**
- add extension-side relay configuration persisted in `chrome.storage.local` (`host`, `port`, optional `token`)
- add an extension Options page to configure relay endpoint so extension can connect to non-localhost relays (for example Tailscale IPs)
- add an opt-in relay server mode for remote extension connections via `playwriter serve --allow-remote-extension`
- keep secure defaults: `/extension` remains localhost-only unless explicitly enabled, and remote extension mode requires token validation

**Why**
- current extension behavior hardcodes `127.0.0.1:19988`, which blocks headless/remote workflows where Chrome runs on another machine and relay connectivity is over private networking like Tailscale

**Testing**
- `pnpm --filter playwriter typecheck`
- `pnpm --filter mcp-extension build`

**config_delta**
```yaml
config_delta:
  affordances:
    - add: "Extension Options page for relay host/port/token"
    - add: "Relay server flag --allow-remote-extension for non-localhost extension WS clients"
  invariants:
    - strengthen: "Default behavior keeps /extension localhost-only"
    - strengthen: "Remote extension path requires token auth"
  constraints:
    - add: "Remote extension connections are rejected unless allow-remote-extension is enabled"
  rationale:
    - "Enable practical remote/headless setups (Tailscale/private IP relays) without weakening defaults"
  enforcement:
    - types: "playwriter/src/cdp-relay.ts option typing + cli option typing"
    - runtime: "token check on /extension when remote extension mode is enabled"
```