### PR TITLE
feat: add --docker flag for container deployments

### DIFF
--- a/playwriter/src/cli.ts
+++ b/playwriter/src/cli.ts
@@ -448,7 +448,7 @@ cli
 
 cli
   .command('serve', 'Start the CDP relay server for remote MCP connections')
-  .option('--host <host>', 'Host to bind to', { default: '0.0.0.0' })
+  .option('--host <host>', 'Host to bind to', { default: 'localhost' })
   .option('--token <token>', 'Authentication token (or use PLAYWRITER_TOKEN env var)')
   .option('--replace', 'Kill existing server if running')
   .action(async (options: { host: string; token?: string; replace?: boolean }) => {


### PR DESCRIPTION
## Summary

When running `playwriter serve` (or letting the relay auto-start) inside a Docker container with a forwarded port, the host machine's Chrome extension connects via the Docker bridge gateway IP (e.g. `172.17.0.1`) rather than `127.0.0.1`. The existing hard-coded localhost checks reject this. This PR adds first-class Docker support.

### Changes

- **`PLAYWRITER_DOCKER=1` env var** — the primary mechanism. When set in the container environment, the relay auto-starts in Docker mode whenever the agent first calls `playwriter session new`. No extra steps needed from the agent.
- **`--docker` flag on `playwriter serve`** — for cases where the relay is started manually. Also recognised via `PLAYWRITER_DOCKER=1`.
- **`detectDockerGateway()`** in `utils.ts` — reads `/proc/net/route` to find the container's default gateway (the Docker bridge host IP). Shared by both the auto-start and serve paths.
- **`trustedLocalAddresses` option on `startPlayWriterCDPRelayServer` / `startServer`** — a general escape hatch: IPs in this list are treated identically to `127.0.0.1` across all three security gates (the `/extension` IP guard, `/cdp` token check, and privileged-route middleware).
- **`isLocalAddress()` helper** inside the relay server — unifies the localhost check, removing duplicated `127.0.0.1 || ::1` literals.
- **`skill.md`** — documents Docker usage for agents running inside containers.

### Usage

**Preferred (Dockerfile):**
```dockerfile
ENV PLAYWRITER_DOCKER=1
# relay auto-starts in Docker mode on first `playwriter session new`
```

**Manual:**
```bash
playwriter serve --docker
# Docker mode: trusting gateway IP 172.17.0.1 as local
# Playwriter CDP relay server started
#   Host: 0.0.0.0  Port: 19988  Trusted local IPs: 172.17.0.1
```

🤖 Developed by [Claude Code](https://claude.com/claude-code) under the supervision of @andrew-from-toronto