### PR TITLE
feat: custom tab group names and colors per session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -783,3 +783,26 @@ const jsonSchema = toJSONSchema(mySchema, {
 ```
 
 github.md
+
+<!-- opensrc:start -->
+
+## Source Code Reference
+
+Source code for dependencies is available in `opensrc/` for deeper understanding of implementation details.
+
+See `opensrc/sources.json` for the list of available packages and their versions.
+
+Use this source code when you need to understand how a package works internally, not just its types/interface.
+
+### Fetching Additional Source Code
+
+To fetch source code for a package or repository you need to understand, run:
+
+```bash
+npx opensrc <package>           # npm package (e.g., npx opensrc zod)
+npx opensrc pypi:<package>      # Python package (e.g., npx opensrc pypi:requests)
+npx opensrc crates:<package>    # Rust crate (e.g., npx opensrc crates:serde)
+npx opensrc <owner>/<repo>      # GitHub repo (e.g., npx opensrc vercel/ai)
+```
+
+<!-- opensrc:end -->

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.0.77
+
+### Bug Fixes
+
+- **Fix tab group flapping causing tab disconnects with multiple sessions**: When two sessions existed with different group names (e.g. "hackernews explorer" and "reddit explorer"), broadcast CDP commands like `Target.setAutoAttach` would overwrite unrelated tabs' group metadata with the sender's session group. This caused `syncTabGroup` to continuously shuffle tabs between groups, and the temporary `chrome.tabs.ungroup()` during the move fired `onUpdated` with `groupId=-1`, which the handler misinterpreted as a manual removal — disconnecting the tab. Fixed by:
+  - Only applying group metadata on `Target.createTarget` (tab creation), not on every CDP command
+  - Adding a `tabsBeingMoved` guard set so `syncTabGroup`'s programmatic ungroup/regroup doesn't trigger disconnects
+  - Narrowing the store subscriber to only trigger `syncTabGroup` on group-relevant field changes (state, groupName, groupColor), not unrelated tab field updates
+
+## 0.0.76
+
+### Bug Fixes
+
+- **Fix tab group color not applying (white group)**: `chrome.tabGroups.update()` can race with `chrome.tabs.group()` — Chrome hasn't fully initialized the group internally when the update runs, leaving it with the default grey/white color. Added retry logic with verification: after each update attempt, the actual group color is read back and compared; if it doesn't match, the update is retried with increasing delays (up to 2 retries).
+
+## 0.0.75
+
+### Features
+
+- **Custom tab group names and colors**: Sessions can now specify a custom Chrome tab group name and color. Tabs from different sessions with different names are placed in separate Chrome tab groups. The relay forwards `groupName` and `groupColor` in every `forwardCDPCommand`, and the extension manages multiple groups accordingly. Default behavior (single "playwriter" green group) is unchanged when no custom name/color is set.
+
 ## 0.0.74
 
 ### Bug Fixes

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Playwriter",
-  "version": "0.0.74",
+  "version": "0.0.77",
   "description": "Automate your Browser using Cursor, Claude, VS Code. More capable and context efficient than Playwright MCP.",
   "permissions": [
     "alarms",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-extension",
-  "version": "0.0.72",
+  "version": "0.0.76",
   "description": "Playwright MCP Browser Extension",
   "private": true,
   "repository": {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -108,6 +108,10 @@ const TAB_GROUP_TITLE = 'playwriter'
 let childSessions: Map<string, { tabId: number; targetId?: string }> = new Map()
 let nextSessionId = 1
 let tabGroupQueue: Promise<void> = Promise.resolve()
+// Guard set: tab IDs currently being moved by syncTabGroup (ungroup → regroup).
+// The onUpdated handler checks this to avoid disconnecting tabs that are being
+// programmatically shuffled between groups (chrome.tabs.ungroup fires groupId=-1).
+const tabsBeingMoved = new Set<number>()
 // Cache Target.setAutoAttach params so existing and future tabs enable OOPIF target events.
 // This ensures Playwright can build the iframe frame tree when connecting over CDP.
 let autoAttachParams: Protocol.Target.SetAutoAttachRequest | null = null
@@ -711,80 +715,212 @@ export function sendMessage(message: any): void {
   }
 }
 
-async function syncTabGroup(): Promise<void> {
+/** Derive the set of managed group titles from a tabs map. */
+function getManagedGroupTitles(tabs: Map<number, TabInfo>): Set<string> {
+  const titles = new Set<string>([TAB_GROUP_TITLE])
+  for (const info of tabs.values()) {
+    titles.add(info.groupName || TAB_GROUP_TITLE)
+  }
+  return titles
+}
+
+const VALID_GROUP_COLORS = new Set<chrome.tabGroups.ColorEnum>([
+  'grey', 'blue', 'red', 'yellow', 'green', 'pink', 'purple', 'cyan', 'orange',
+])
+
+function toValidGroupColor(color: string | undefined): chrome.tabGroups.ColorEnum {
+  if (color && VALID_GROUP_COLORS.has(color as chrome.tabGroups.ColorEnum)) {
+    return color as chrome.tabGroups.ColorEnum
+  }
+  return TAB_GROUP_COLOR
+}
+
+/**
+ * chrome.tabGroups.update() can fail silently after chrome.tabs.group() due to a
+ * race condition: Chrome hasn't fully initialized the group internally when the
+ * update call runs, leaving the group with default grey/white color. Retrying
+ * after a short delay fixes this reliably.
+ */
+async function updateTabGroupWithRetry(
+  groupId: number,
+  properties: chrome.tabGroups.UpdateProperties,
+  { maxRetries = 2, delayMs = 50 }: { maxRetries?: number; delayMs?: number } = {},
+): Promise<void> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      if (attempt > 0) {
+        await new Promise((resolve) => {
+          setTimeout(resolve, delayMs * attempt)
+        })
+      }
+      await chrome.tabGroups.update(groupId, properties)
+      // Verify the color actually applied (Chrome can silently ignore the update)
+      if (properties.color) {
+        const group = await chrome.tabGroups.get(groupId)
+        if (group.color !== properties.color) {
+          logger.debug('Tab group color mismatch after update, retrying:', groupId, group.color, '→', properties.color)
+          continue
+        }
+      }
+      return
+    } catch (e: any) {
+      if (attempt === maxRetries) {
+        logger.debug('Failed to update tab group after retries:', groupId, e.message)
+      }
+    }
+  }
+}
+
+async function syncTabGroup({ prevTabs }: { prevTabs?: Map<number, TabInfo> } = {}): Promise<void> {
   try {
     // Include 'connecting' tabs in the group only when the relay is alive, so that
     // tabs the user drags into the group stay visible while attaching. When the relay
     // is dead all tabs are 'connecting' (waiting for reconnect) and the group should
-    // be cleaned up. The onUpdated handler (line ~1601) already guards against the
+    // be cleaned up. The onUpdated handler already guards against the
     // ungroup→disconnect loop for 'connecting' tabs, so excluding them here is safe.
-    const { connectionState } = store.getState()
+    const { connectionState, tabs: currentTabs } = store.getState()
     const isRelayConnected = connectionState === 'connected'
-    const connectedTabIds = Array.from(store.getState().tabs.entries())
-      .filter(([_, info]) => info.state === 'connected' || (info.state === 'connecting' && isRelayConnected))
-      .map(([tabId]) => tabId)
+    const connectedTabs = Array.from(currentTabs.entries())
+      .filter(([_, info]) => {
+        return info.state === 'connected' || (info.state === 'connecting' && isRelayConnected)
+      })
 
-    // Always query by title - no cached ID that can go stale
-    const existingGroups = await chrome.tabGroups.query({ title: TAB_GROUP_TITLE })
+    // Build a map of groupName → { tabIds, color } for desired state
+    const desiredGroups = new Map<string, { tabIds: number[]; color: chrome.tabGroups.ColorEnum }>()
+    for (const [tabId, info] of connectedTabs) {
+      const name = info.groupName || TAB_GROUP_TITLE
+      const color = toValidGroupColor(info.groupColor)
+      const existing = desiredGroups.get(name)
+      if (existing) {
+        existing.tabIds.push(tabId)
+      } else {
+        desiredGroups.set(name, { tabIds: [tabId], color })
+      }
+    }
 
-    // If no connected tabs, clear any existing playwriter groups
-    if (connectedTabIds.length === 0) {
-      for (const group of existingGroups) {
+    // Derive the full set of titles to query: union of current + previous tabs.
+    // Previous tabs may have had group names whose tabs just disconnected — we need
+    // to find those Chrome groups to clean them up.
+    const currentTitles = getManagedGroupTitles(currentTabs)
+    const previousTitles = prevTabs ? getManagedGroupTitles(prevTabs) : new Set<string>()
+    const allTitlesToQuery = new Set([...currentTitles, ...previousTitles])
+
+    // Collect all Chrome tab groups that match any managed title
+    const allManagedGroups: chrome.tabGroups.TabGroup[] = []
+    for (const title of allTitlesToQuery) {
+      const groups = await chrome.tabGroups.query({ title })
+      allManagedGroups.push(...groups)
+    }
+
+    // If no connected tabs, clear all managed groups
+    if (connectedTabs.length === 0) {
+      for (const group of allManagedGroups) {
         const tabsInGroup = await chrome.tabs.query({ groupId: group.id })
         const tabIdsToUngroup = tabsInGroup.map((t) => t.id).filter((id): id is number => id !== undefined)
         if (tabIdsToUngroup.length > 0) {
-          await chrome.tabs.ungroup(tabIdsToUngroup)
+          for (const id of tabIdsToUngroup) {
+            tabsBeingMoved.add(id)
+          }
+          try {
+            await chrome.tabs.ungroup(tabIdsToUngroup)
+          } finally {
+            for (const id of tabIdsToUngroup) {
+              tabsBeingMoved.delete(id)
+            }
+          }
         }
-        logger.debug('Cleared playwriter group:', group.id)
+        logger.debug('Cleared managed group:', group.title, group.id)
       }
       return
     }
 
-    // Consolidate duplicate groups into one
-    let groupId: number | undefined = existingGroups[0]?.id
-    if (existingGroups.length > 1) {
-      const [keep, ...duplicates] = existingGroups
-      groupId = keep.id
-      for (const group of duplicates) {
-        const tabsInDupe = await chrome.tabs.query({ groupId: group.id })
-        const tabIdsToUngroup = tabsInDupe.map((t) => t.id).filter((id): id is number => id !== undefined)
-        if (tabIdsToUngroup.length > 0) {
-          await chrome.tabs.ungroup(tabIdsToUngroup)
+    // For each desired group, find or create the Chrome tab group and sync membership.
+    // We query current group membership live per group (not a stale snapshot) to avoid
+    // cross-group move bugs when multiple groups are updated in one sync.
+    for (const [groupName, { tabIds: desiredTabIds, color }] of desiredGroups) {
+      const matchingGroups = allManagedGroups.filter((g) => g.title === groupName)
+
+      // Consolidate duplicates: keep first, ungroup tabs in duplicates
+      let groupId: number | undefined = matchingGroups[0]?.id
+      if (matchingGroups.length > 1) {
+        const [keep, ...duplicates] = matchingGroups
+        groupId = keep.id
+        for (const dupe of duplicates) {
+          const tabsInDupe = await chrome.tabs.query({ groupId: dupe.id })
+          const idsToUngroup = tabsInDupe.map((t) => t.id).filter((id): id is number => id !== undefined)
+          if (idsToUngroup.length > 0) {
+            await chrome.tabs.ungroup(idsToUngroup)
+          }
+          logger.debug('Removed duplicate group:', groupName, dupe.id)
         }
-        logger.debug('Removed duplicate playwriter group:', group.id)
+      }
+
+      const desiredSet = new Set(desiredTabIds)
+      // Query live membership for this specific group (avoids stale snapshot issues)
+      const currentTabsInGroup = groupId !== undefined
+        ? await chrome.tabs.query({ groupId })
+        : []
+      const currentIdsInGroup = new Set(
+        currentTabsInGroup.map((t) => t.id).filter((id): id is number => id !== undefined),
+      )
+
+      const tabsToAdd = desiredTabIds.filter((id) => !currentIdsInGroup.has(id))
+      const tabsToRemove = Array.from(currentIdsInGroup).filter((id) => !desiredSet.has(id))
+
+      if (tabsToRemove.length > 0) {
+        try {
+          // Mark tabs as being moved so onUpdated doesn't disconnect them when
+          // chrome.tabs.ungroup fires groupId=-1
+          for (const id of tabsToRemove) {
+            tabsBeingMoved.add(id)
+          }
+          await chrome.tabs.ungroup(tabsToRemove)
+          logger.debug('Removed tabs from group', groupName, ':', tabsToRemove)
+        } catch (e: any) {
+          logger.debug('Failed to ungroup tabs:', tabsToRemove, e.message)
+        } finally {
+          for (const id of tabsToRemove) {
+            tabsBeingMoved.delete(id)
+          }
+        }
+      }
+
+      if (tabsToAdd.length > 0) {
+        if (groupId === undefined) {
+          const newGroupId = await chrome.tabs.group({ tabIds: tabsToAdd })
+          await updateTabGroupWithRetry(newGroupId, { title: groupName, color })
+          logger.debug('Created tab group:', groupName, newGroupId, 'with tabs:', tabsToAdd)
+        } else {
+          await chrome.tabs.group({ tabIds: tabsToAdd, groupId })
+          await updateTabGroupWithRetry(groupId, { title: groupName, color })
+          logger.debug('Added tabs to group', groupName, ':', tabsToAdd)
+        }
+      } else if (groupId !== undefined) {
+        // Ensure the existing group keeps the right color/title.
+        // Chrome can reset these on group collapse/expand or tab moves.
+        await updateTabGroupWithRetry(groupId, { title: groupName, color })
       }
     }
 
-    const allTabs = await chrome.tabs.query({})
-    const tabsInGroup = allTabs.filter((t) => t.groupId === groupId && t.id !== undefined)
-    const tabIdsInGroup = new Set(tabsInGroup.map((t) => t.id!))
-
-    const tabsToAdd = connectedTabIds.filter((id) => !tabIdsInGroup.has(id))
-    const tabsToRemove = Array.from(tabIdsInGroup).filter((id) => !connectedTabIds.includes(id))
-
-    if (tabsToRemove.length > 0) {
-      try {
-        await chrome.tabs.ungroup(tabsToRemove)
-        logger.debug('Removed tabs from group:', tabsToRemove)
-      } catch (e: any) {
-        logger.debug('Failed to ungroup tabs:', tabsToRemove, e.message)
+    // Clean up managed groups that no longer have any desired tabs
+    for (const group of allManagedGroups) {
+      if (group.title && !desiredGroups.has(group.title)) {
+        const tabsInGroup = await chrome.tabs.query({ groupId: group.id })
+        const tabIdsToUngroup = tabsInGroup.map((t) => t.id).filter((id): id is number => id !== undefined)
+        if (tabIdsToUngroup.length > 0) {
+          for (const id of tabIdsToUngroup) {
+            tabsBeingMoved.add(id)
+          }
+          try {
+            await chrome.tabs.ungroup(tabIdsToUngroup)
+          } finally {
+            for (const id of tabIdsToUngroup) {
+              tabsBeingMoved.delete(id)
+            }
+          }
+        }
+        logger.debug('Cleaned up empty managed group:', group.title, group.id)
       }
-    }
-
-    if (tabsToAdd.length > 0) {
-      if (groupId === undefined) {
-        const newGroupId = await chrome.tabs.group({ tabIds: tabsToAdd })
-        await chrome.tabGroups.update(newGroupId, { title: TAB_GROUP_TITLE, color: TAB_GROUP_COLOR })
-        logger.debug('Created tab group:', newGroupId, 'with tabs:', tabsToAdd)
-      } else {
-        await chrome.tabs.group({ tabIds: tabsToAdd, groupId })
-        await chrome.tabGroups.update(groupId, { title: TAB_GROUP_TITLE, color: TAB_GROUP_COLOR })
-        logger.debug('Added tabs to existing group:', tabsToAdd)
-      }
-    } else if (groupId !== undefined) {
-      // No tabs to add, but ensure the existing group keeps the right color/title.
-      // Chrome can reset these on group collapse/expand or tab moves.
-      await chrome.tabGroups.update(groupId, { title: TAB_GROUP_TITLE, color: TAB_GROUP_COLOR })
     }
   } catch (error: any) {
     logger.debug('Failed to sync tab group:', error.message)
@@ -884,6 +1020,16 @@ async function handleCommand(msg: ExtensionCommandMessage): Promise<any> {
   let targetTabId = resolved?.tabId
   let targetTab = resolved?.tab
 
+  // Group metadata (groupName/groupColor) is intentionally NOT applied here on
+  // every command. The relay only sends these fields on Target.createTarget, and
+  // the extension applies them in the Target.createTarget handler below.
+  // Previously, applying group fields on every command caused a flapping bug:
+  // broadcast commands (like Target.setAutoAttach) would overwrite unrelated tabs'
+  // group metadata with the sender's session group, making syncTabGroup continuously
+  // shuffle tabs between groups and triggering disconnects.
+  const msgGroupName = msg.params.groupName
+  const msgGroupColor = msg.params.groupColor
+
   const debuggee = targetTabId ? { tabId: targetTabId } : undefined
 
   // Root-level Target.setAutoAttach must apply to all connected tabs since
@@ -954,6 +1100,17 @@ async function handleCommand(msg: ExtensionCommandMessage): Promise<any> {
       logger.debug('Created tab:', tab.id, 'waiting for it to load...')
       await sleep(100)
       const { targetInfo } = await attachTab(tab.id)
+      // Apply group metadata from the command to the newly created tab
+      if (tab.id && (msgGroupName || msgGroupColor)) {
+        store.setState((state) => {
+          const newTabs = new Map(state.tabs)
+          const tabInfo = newTabs.get(tab.id!)
+          if (tabInfo) {
+            newTabs.set(tab.id!, { ...tabInfo, groupName: msgGroupName, groupColor: msgGroupColor })
+          }
+          return { tabs: newTabs }
+        })
+      }
       return { targetId: targetInfo.targetId } satisfies Protocol.Target.CreateTargetResponse
     }
 
@@ -1124,11 +1281,14 @@ async function attachTab(
 
     store.setState((state) => {
       const newTabs = new Map(state.tabs)
+      const existing = newTabs.get(tabId)
       newTabs.set(tabId, {
+        ...existing,
         sessionId,
         targetId: targetInfo.targetId,
         state: 'connected',
         attachOrder,
+        errorText: undefined,
       })
       return { tabs: newTabs, connectionState: 'connected', errorText: undefined }
     })
@@ -1557,17 +1717,25 @@ chrome.runtime.onInstalled.addListener((details) => {
   }
 })
 
-function serializeTabs(tabs: Map<number, TabInfo>): string {
-  return JSON.stringify(Array.from(tabs.entries()))
+// Only compare group-relevant fields to avoid triggering syncTabGroup on unrelated
+// tab changes (pinnedCount, isRecording, etc.) that don't affect group membership.
+function serializeGroupProjection(tabs: Map<number, TabInfo>): string {
+  const projection = Array.from(tabs.entries()).map(([id, info]) => {
+    return [id, info.state, info.groupName, info.groupColor] as const
+  })
+  return JSON.stringify(projection)
 }
 
 store.subscribe((state, prevState) => {
   logger.log(state)
   void updateIcons()
   updateContextMenuVisibility()
-  const tabsChanged = serializeTabs(state.tabs) !== serializeTabs(prevState.tabs)
-  if (tabsChanged) {
-    tabGroupQueue = tabGroupQueue.then(syncTabGroup).catch((e) => {
+  const groupChanged = serializeGroupProjection(state.tabs) !== serializeGroupProjection(prevState.tabs)
+  if (groupChanged) {
+    const prevTabs = prevState.tabs
+    tabGroupQueue = tabGroupQueue.then(() => {
+      return syncTabGroup({ prevTabs })
+    }).catch((e) => {
       logger.debug('syncTabGroup error:', e)
     })
   }
@@ -1637,16 +1805,37 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     // Queue tab group operations to serialize with syncTabGroup and disconnectEverything
     tabGroupQueue = tabGroupQueue
       .then(async () => {
-        // Query for playwriter group by title - no stale cached ID
-        const existingGroups = await chrome.tabGroups.query({ title: TAB_GROUP_TITLE })
-        const groupId = existingGroups[0]?.id
-        if (groupId === undefined) {
+        // Derive managed titles from current store tabs (default + any custom group names)
+        const currentManagedTitles = getManagedGroupTitles(store.getState().tabs)
+        // Build a map from Chrome group ID → { title, color } so we can persist
+        // group metadata when a tab is manually dragged into a managed group
+        const managedGroupInfo = new Map<number, { title: string; color: string }>()
+        for (const title of currentManagedTitles) {
+          const groups = await chrome.tabGroups.query({ title })
+          for (const g of groups) {
+            managedGroupInfo.set(g.id, { title: g.title || TAB_GROUP_TITLE, color: g.color || TAB_GROUP_COLOR })
+          }
+        }
+        if (managedGroupInfo.size === 0) {
           return
         }
         const { tabs } = store.getState()
-        if (changeInfo.groupId === groupId) {
+        if (managedGroupInfo.has(changeInfo.groupId!)) {
           if (!tabs.has(tabId) && !isRestrictedUrl(tab.url)) {
-            logger.debug('Tab manually added to playwriter group:', tabId)
+            // Persist the group's title/color on the tab before connecting so
+            // syncTabGroup keeps it in the correct group after attach
+            const groupMeta = managedGroupInfo.get(changeInfo.groupId!)!
+            store.setState((state) => {
+              const newTabs = new Map(state.tabs)
+              newTabs.set(tabId, {
+                ...newTabs.get(tabId),
+                state: 'connecting' as TabState,
+                groupName: groupMeta.title,
+                groupColor: groupMeta.color,
+              })
+              return { tabs: newTabs }
+            })
+            logger.debug('Tab manually added to managed group:', tabId, groupMeta.title)
             await connectTab(tabId)
           }
         } else if (tabs.has(tabId)) {
@@ -1655,7 +1844,13 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
             logger.debug('Tab removed from group while connecting, ignoring:', tabId)
             return
           }
-          logger.debug('Tab manually removed from playwriter group:', tabId)
+          // syncTabGroup temporarily ungroups tabs during moves, which fires
+          // onUpdated with groupId=-1. Skip disconnect for tabs being moved.
+          if (tabsBeingMoved.has(tabId)) {
+            logger.debug('Tab being moved by syncTabGroup, ignoring ungroup event:', tabId)
+            return
+          }
+          logger.debug('Tab manually removed from managed group:', tabId)
           await disconnectTab(tabId)
         }
       })

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -9,6 +9,10 @@ export interface TabInfo {
   pinnedCount?: number
   attachOrder?: number
   isRecording?: boolean
+  /** Chrome tab group name for this tab's session (default: 'playwriter') */
+  groupName?: string
+  /** Chrome tab group color for this tab's session (default: 'green') */
+  groupColor?: string
 }
 
 export interface ExtensionState {

--- a/playwriter/CHANGELOG.md
+++ b/playwriter/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.0.87
+
+### Bug Fixes
+
+- **Fix tab group flapping with multiple sessions**: Only send `groupName`/`groupColor` fields on `Target.createTarget` commands, not on every `forwardCDPCommand`. Previously, broadcast commands like `Target.setAutoAttach` would inject the sender's group metadata into every CDP command, overwriting unrelated tabs' group assignments and causing disconnects.
+
+## 0.0.86
+
+### Features
+
+- **Custom session tab group names and colors**: `playwriter session new` now accepts `--name` and `--color` options to control the Chrome tab group name and color for that session's tabs. Different sessions with different names get separate tab groups. The group metadata flows through the CDP URL query params → relay state → `forwardCDPCommand` params → extension `TabInfo`. Backward compatible: older extensions ignore the new fields, and omitting the options preserves the default "playwriter" green group.
+
 ## 0.0.85
 
 ### Bug Fixes

--- a/playwriter/package.json
+++ b/playwriter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playwriter",
   "description": "",
-  "version": "0.0.85",
+  "version": "0.0.87",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/playwriter/src/cdp-relay.ts
+++ b/playwriter/src/cdp-relay.ts
@@ -563,16 +563,29 @@ export async function startPlayWriterCDPRelayServer({
     params,
     sessionId,
     source,
+    clientId,
   }: {
     extensionId: string | null
     method: CDPCommand['method'] | (string & {})
     params: CDPCommand['params']
     sessionId?: CDPCommand['sessionId']
     source?: CDPCommand['source']
+    clientId?: string
   }) {
     const conn = getExtensionConnection(extensionId)
     const connectedTargets = conn?.connectedTargets || new Map<string, relayState.ConnectedTarget>()
     const resolvedExtensionId = conn?.id || extensionId
+
+    // Look up tab group metadata from the Playwright client that sent this command.
+    // Only included on Target.createTarget — NOT on every command. Sending group
+    // fields on every command caused a flapping bug: broadcast commands like
+    // Target.setAutoAttach would overwrite unrelated tabs' group metadata, making
+    // syncTabGroup continuously shuffle tabs between groups and triggering disconnects.
+    const client = clientId ? store.getState().playwrightClients.get(clientId) : undefined
+    const groupFields = method === 'Target.createTarget' && (client?.groupName || client?.groupColor)
+      ? { groupName: client.groupName, groupColor: client.groupColor }
+      : {}
+
     switch (method) {
       case 'Browser.getVersion': {
         return {
@@ -603,7 +616,7 @@ export async function startPlayWriterCDPRelayServer({
         await sendToExtension({
           extensionId: resolvedExtensionId,
           method: 'forwardCDPCommand',
-          params: { method, params, source },
+          params: { method, params, source, ...groupFields },
         })
         return {}
       }
@@ -665,7 +678,7 @@ export async function startPlayWriterCDPRelayServer({
         return await sendToExtension({
           extensionId: resolvedExtensionId,
           method: 'forwardCDPCommand',
-          params: { method, params, source },
+          params: { method, params, source, ...groupFields },
         })
       }
 
@@ -673,7 +686,7 @@ export async function startPlayWriterCDPRelayServer({
         return await sendToExtension({
           extensionId: resolvedExtensionId,
           method: 'forwardCDPCommand',
-          params: { method, params, source },
+          params: { method, params, source, ...groupFields },
         })
       }
 
@@ -717,7 +730,7 @@ export async function startPlayWriterCDPRelayServer({
         const result = await sendToExtension({
           extensionId: resolvedExtensionId,
           method: 'forwardCDPCommand',
-          params: { sessionId, method, params, source },
+          params: { sessionId, method, params, source, ...groupFields },
         })
 
         await contextCreatedPromise
@@ -729,7 +742,7 @@ export async function startPlayWriterCDPRelayServer({
     return await sendToExtension({
       extensionId: resolvedExtensionId,
       method: 'forwardCDPCommand',
-      params: { sessionId, method, params, source },
+      params: { sessionId, method, params, source, ...groupFields },
     })
   }
 
@@ -925,6 +938,8 @@ export async function startPlayWriterCDPRelayServer({
       const clientId = c.req.param('clientId') || 'default'
       const url = new URL(c.req.url, 'http://localhost')
       const requestedExtensionId = url.searchParams.get('extensionId')
+      const clientGroupName = url.searchParams.get('groupName') || undefined
+      const clientGroupColor = url.searchParams.get('groupColor') || undefined
       // When extensionId is explicit, resolve directly. Otherwise use fallback which
       // handles single-extension and uniquely-active-extension cases (#52).
       const resolvedExtension = requestedExtensionId
@@ -956,7 +971,7 @@ export async function startPlayWriterCDPRelayServer({
 
           // Add client first so it can receive Target.attachedToTarget events
           store.setState((s) => {
-            return relayState.addPlaywrightClient(s, { id: clientId, extensionId: clientExtensionId, ws })
+            return relayState.addPlaywrightClient(s, { id: clientId, extensionId: clientExtensionId, ws, groupName: clientGroupName, groupColor: clientGroupColor })
           })
           const extensionConnection = getExtensionConnection(clientExtensionId)
           const targetCount = extensionConnection?.connectedTargets.size || 0
@@ -1016,6 +1031,7 @@ export async function startPlayWriterCDPRelayServer({
               params,
               sessionId,
               source,
+              clientId,
             })
 
             if (method === 'Target.setAutoAttach' && !sessionId) {
@@ -1767,7 +1783,7 @@ export async function startPlayWriterCDPRelayServer({
   })
 
   app.post('/cli/session/new', async (c) => {
-    const body = (await c.req.json().catch(() => ({}))) as { extensionId?: string | null; cwd?: string }
+    const body = (await c.req.json().catch(() => ({}))) as { extensionId?: string | null; cwd?: string; groupName?: string; groupColor?: string }
     const sessionId = String(nextSessionNumber++)
     const extensionId = body.extensionId || null
     const cwd = body.cwd
@@ -1787,6 +1803,8 @@ export async function startPlayWriterCDPRelayServer({
         extensionId: conn.stableKey,
         browser: conn.info.browser || null,
         profile: conn.info ? { email: conn.info.email || '', id: conn.info.id || '' } : null,
+        groupName: body.groupName,
+        groupColor: body.groupColor,
       },
     })
     const metadata = executor.getSessionMetadata()

--- a/playwriter/src/cli.ts
+++ b/playwriter/src/cli.ts
@@ -208,7 +208,18 @@ cli
   .command('session new', 'Create a new session and print the session ID')
   .option('--host <host>', 'Remote relay server host')
   .option('--browser <stableKey>', 'Stable browser key when multiple browsers are connected')
-  .action(async (options: { host?: string; browser?: string }) => {
+  .option('--name <name>', 'Tab group name (default: playwriter)')
+  .option('--color <color>', 'Tab group color: grey, blue, red, yellow, green, pink, purple, cyan, orange (default: green)')
+  .action(async (options: { host?: string; browser?: string; name?: string; color?: string }) => {
+    const validColors = ['grey', 'blue', 'red', 'yellow', 'green', 'pink', 'purple', 'cyan', 'orange']
+    if (options.color && !validColors.includes(options.color.toLowerCase())) {
+      console.error(`Invalid color: ${options.color}. Must be one of: ${validColors.join(', ')}`)
+      process.exit(1)
+    }
+    if (options.color) {
+      options.color = options.color.toLowerCase()
+    }
+
     const isLocal = !options.host && !process.env.PLAYWRITER_HOST
 
     let extensions: ExtensionStatus[] = []
@@ -286,7 +297,7 @@ cli
       const response = await fetch(`${serverUrl}/cli/session/new`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ extensionId, cwd }),
+        body: JSON.stringify({ extensionId, cwd, groupName: options.name, groupColor: options.color }),
       })
       if (!response.ok) {
         const text = await response.text()

--- a/playwriter/src/executor.ts
+++ b/playwriter/src/executor.ts
@@ -217,12 +217,16 @@ export interface CdpConfig {
   port?: number
   token?: string
   extensionId?: string | null
+  groupName?: string
+  groupColor?: string
 }
 
 export interface SessionMetadata {
   extensionId: string | null
   browser: string | null
   profile: { email: string; id: string } | null
+  groupName?: string
+  groupColor?: string
 }
 
 export interface ExecutorOptions {
@@ -1276,9 +1280,12 @@ export class ExecutorManager {
     let executor = this.executors.get(sessionId)
     if (!executor) {
       const baseConfig = typeof this.cdpConfig === 'function' ? this.cdpConfig(sessionId) : this.cdpConfig
-      const cdpConfig = sessionMetadata?.extensionId
-        ? { ...baseConfig, extensionId: sessionMetadata.extensionId }
-        : baseConfig
+      const cdpConfig = {
+        ...baseConfig,
+        ...(sessionMetadata?.extensionId ? { extensionId: sessionMetadata.extensionId } : {}),
+        ...(sessionMetadata?.groupName ? { groupName: sessionMetadata.groupName } : {}),
+        ...(sessionMetadata?.groupColor ? { groupColor: sessionMetadata.groupColor } : {}),
+      }
       executor = new PlaywrightExecutor({
         cdpConfig,
         sessionMetadata,

--- a/playwriter/src/protocol.ts
+++ b/playwriter/src/protocol.ts
@@ -11,6 +11,10 @@ type ForwardCDPCommand = {
       sessionId?: string
       params?: ProtocolMapping.Commands[K]['paramsType'][0]
       source?: 'playwriter'
+      /** Tab group name for this session's tabs (extension uses for chrome.tabGroups) */
+      groupName?: string
+      /** Tab group color for this session's tabs (chrome.tabGroups.ColorEnum value) */
+      groupColor?: string
     }
   }
 }[keyof ProtocolMapping.Commands]

--- a/playwriter/src/relay-state.ts
+++ b/playwriter/src/relay-state.ts
@@ -56,6 +56,8 @@ export type PlaywrightClient = {
   id: string
   extensionId: string | null
   ws: WSContext
+  groupName?: string
+  groupColor?: string
 }
 
 export type RelayState = {
@@ -172,10 +174,10 @@ export function removeExtension(state: RelayState, { extensionId }: { extensionI
 /** Add a playwright client (state + ws handle co-located). */
 export function addPlaywrightClient(
   state: RelayState,
-  { id, extensionId, ws }: { id: string; extensionId: string | null; ws: WSContext },
+  { id, extensionId, ws, groupName, groupColor }: { id: string; extensionId: string | null; ws: WSContext; groupName?: string; groupColor?: string },
 ): RelayState {
   const newClients = new Map(state.playwrightClients)
-  newClients.set(id, { id, extensionId, ws })
+  newClients.set(id, { id, extensionId, ws, groupName, groupColor })
   return { ...state, playwrightClients: newClients }
 }
 

--- a/playwriter/src/skill.md
+++ b/playwriter/src/skill.md
@@ -24,6 +24,9 @@ Get a new session ID to use in commands:
 ```bash
 playwriter session new
 # outputs: 1
+
+# label tabs with project name and color (grey/blue/red/yellow/green/pink/purple/cyan/orange)
+playwriter session new --name myproject --color red
 ```
 
 **Always use your own session** - pass `-s <id>` to all commands. Using the same session preserves your `state` between calls. Using a different session gives you a fresh `state`.

--- a/playwriter/src/utils.ts
+++ b/playwriter/src/utils.ts
@@ -36,11 +36,15 @@ export function getCdpUrl({
   host = '127.0.0.1',
   token,
   extensionId,
+  groupName,
+  groupColor,
 }: {
   port?: number
   host?: string
   token?: string
   extensionId?: string | null
+  groupName?: string
+  groupColor?: string
 } = {}) {
   const id = `${Math.random().toString(36).substring(2, 15)}_${Date.now()}`
   const params = new URLSearchParams()
@@ -49,6 +53,12 @@ export function getCdpUrl({
   }
   if (extensionId) {
     params.set('extensionId', extensionId)
+  }
+  if (groupName) {
+    params.set('groupName', groupName)
+  }
+  if (groupColor) {
+    params.set('groupColor', groupColor)
   }
   const queryString = params.toString()
   const suffix = queryString ? `?${queryString}` : ''

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 7.2.2(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0)
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/node@25.2.0)(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.2.0(bufferutil@4.0.9))(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@25.2.0)(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.2.0(bufferutil@4.0.9))(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0)
 
   extension:
     dependencies:
@@ -407,7 +407,7 @@ importers:
         version: 5.0.0(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0)
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@types/node@24.10.1)(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.2.0(bufferutil@4.0.9))(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0)
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.2.0(bufferutil@4.0.9))(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0)
     optionalDependencies:
       sharp:
         specifier: ^0.34.5
@@ -460,6 +460,9 @@ importers:
       react-router:
         specifier: ^7.11.0
         version: 7.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      safe-mdx:
+        specifier: ^1.3.9
+        version: 1.3.9(react@19.2.3)
       sentries:
         specifier: ^0.2.2
         version: 0.2.2
@@ -514,7 +517,7 @@ importers:
         version: 6.0.3(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0))
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(@vitest/ui@4.0.8(vitest@4.0.8))(jiti@2.6.1)(jsdom@27.2.0(bufferutil@4.0.9))(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.2.0(bufferutil@4.0.9))(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0)
 
 packages:
 
@@ -2713,8 +2716,14 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/debug@4.1.12':
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -2734,6 +2743,9 @@ packages:
   '@types/har-format@1.2.16':
     resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/http-cache-semantics@4.2.0':
     resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
 
@@ -2751,6 +2763,9 @@ packages:
 
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/mysql@2.15.26':
     resolution: {integrity: sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==}
@@ -2818,6 +2833,9 @@ packages:
 
   '@types/tern@0.23.9':
     resolution: {integrity: sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -3194,6 +3212,9 @@ packages:
   babel-dead-code-elimination@1.0.11:
     resolution: {integrity: sha512-mwq3W3e/pKSI6TG8lXMiDWvEi1VXYlSBlJlB3l+I0bAb5u1RNUl88udos85eOPNK3m5EXK9uO7d2g08pesTySQ==}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -3280,6 +3301,9 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
@@ -3351,6 +3375,9 @@ packages:
   caniuse-lite@1.0.30001762:
     resolution: {integrity: sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.1:
     resolution: {integrity: sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==}
     engines: {node: '>=18'}
@@ -3366,6 +3393,18 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -3419,6 +3458,9 @@ packages:
 
   code-block-writer@10.1.1:
     resolution: {integrity: sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==}
+
+  collapse-white-space@2.1.0:
+    resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -3517,14 +3559,24 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
   css-tree@3.1.0:
     resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
 
   cssstyle@5.3.7:
     resolution: {integrity: sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==}
@@ -3609,6 +3661,9 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -3659,6 +3714,10 @@ packages:
   deprecation@2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -3673,6 +3732,9 @@ packages:
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   devtools-protocol@0.0.1312386:
     resolution: {integrity: sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==}
@@ -3711,6 +3773,9 @@ packages:
   dom-serializer@1.4.1:
     resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
   domelementtype@1.3.1:
     resolution: {integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==}
 
@@ -3724,11 +3789,18 @@ packages:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
 
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
   domutils@1.7.0:
     resolution: {integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -3791,8 +3863,16 @@ packages:
     resolution: {integrity: sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==}
     engines: {node: '>=0.12'}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
@@ -3866,6 +3946,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
@@ -3966,6 +4050,12 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-util-visit@2.0.0:
+    resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -3976,6 +4066,9 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  eval-estree-expression@3.0.1:
+    resolution: {integrity: sha512-zTLKGbiVdQYp4rQkSoXPibrFf5ZoPn6jzExegRLEQ13F+FSxu5iLgaRH6hlDs2kWSUa6vp8yD20cdJi0me6pEw==}
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -4071,6 +4164,9 @@ packages:
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
+  fault@2.0.1:
+    resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
+
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
@@ -4154,6 +4250,10 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
 
   formdata-node@4.4.1:
     resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
@@ -4385,6 +4485,12 @@ packages:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
 
+  html-escaper@3.0.3:
+    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   htmlparser2@3.10.1:
     resolution: {integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==}
 
@@ -4473,6 +4579,9 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -4484,6 +4593,12 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -4521,6 +4636,9 @@ packages:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-docker@2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
@@ -4546,6 +4664,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-json@2.0.1:
     resolution: {integrity: sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==}
 
@@ -4564,6 +4685,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -4847,6 +4972,15 @@ packages:
     resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
     engines: {node: '>= 12.0.0'}
 
+  linkedom@0.18.12:
+    resolution: {integrity: sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      canvas: '>= 2'
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -4867,6 +5001,9 @@ packages:
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -4898,6 +5035,9 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   marked@17.0.1:
     resolution: {integrity: sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==}
     engines: {node: '>= 20'}
@@ -4913,6 +5053,54 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-frontmatter@2.0.1:
+    resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdx@3.0.0:
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
@@ -4942,6 +5130,114 @@ packages:
 
   metric-lcs@0.1.2:
     resolution: {integrity: sha512-+TZ5dUDPKPJaU/rscTzxyN8ZkX7eAVLAiQU/e+YINleXPv03SCmJShaMT1If1liTH8OcmWXZs0CmzCBRBLcMpA==}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-frontmatter@2.0.0:
+    resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-extension-mdx-expression@3.0.1:
+    resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
+
+  micromark-extension-mdx-jsx@3.0.2:
+    resolution: {integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==}
+
+  micromark-extension-mdx-md@2.0.0:
+    resolution: {integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==}
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
+
+  micromark-extension-mdxjs@3.0.0:
+    resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-mdx-expression@2.0.3:
+    resolution: {integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-events-to-acorn@2.0.3:
+    resolution: {integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -5111,6 +5407,9 @@ packages:
 
   npm-normalize-package-bin@1.0.1:
     resolution: {integrity: sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -5288,6 +5587,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
@@ -5627,6 +5929,24 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  remark-frontmatter@5.0.0:
+    resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-mdx@3.1.1:
+    resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  remark@15.0.1:
+    resolution: {integrity: sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -5718,6 +6038,11 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-mdx@1.3.9:
+    resolution: {integrity: sha512-lg5YY55sd+3kQk5FDhUObqnTXDr8H6WU3feXql0ZMMImuT5mbvV6zKibUy8OjhK4M5nQtP5Bkof9D7Szyj3x3w==}
+    peerDependencies:
+      react: '*'
 
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
@@ -5974,6 +6299,9 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -5996,6 +6324,9 @@ packages:
 
   strnum@2.1.2:
     resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
@@ -6124,6 +6455,9 @@ packages:
     resolution: {integrity: sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==}
     engines: {node: '>=0.6'}
 
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
@@ -6204,6 +6538,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uhyphen@0.2.0:
+    resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
+
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
@@ -6227,6 +6564,24 @@ packages:
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position-from-estree@2.0.0:
+    resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   universal-user-agent@6.0.1:
     resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
@@ -6290,6 +6645,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -6755,6 +7116,9 @@ packages:
       use-sync-external-store:
         optional: true
 
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
 snapshots:
 
   '@acemir/cssom@0.9.31':
@@ -6888,7 +7252,7 @@ snapshots:
   '@ai-sdk/provider-utils@3.0.18(zod@4.3.5)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.3.5
 
@@ -9193,7 +9557,15 @@ snapshots:
     dependencies:
       '@types/node': 25.2.0
 
+  '@types/debug@4.1.12':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
 
@@ -9211,6 +9583,10 @@ snapshots:
 
   '@types/har-format@1.2.16': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/http-cache-semantics@4.2.0': {}
 
   '@types/json-schema@7.0.15': {}
@@ -9226,6 +9602,8 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/minimist@1.2.5': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/mysql@2.15.26':
     dependencies:
@@ -9307,6 +9685,8 @@ snapshots:
   '@types/tern@0.23.9':
     dependencies:
       '@types/estree': 1.0.8
+
+  '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
@@ -9496,14 +9876,6 @@ snapshots:
     optionalDependencies:
       vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0)
 
-  '@vitest/mocker@4.0.8(vite@7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0))':
-    dependencies:
-      '@vitest/spy': 4.0.8
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0)
-
   '@vitest/mocker@4.0.8(vite@7.2.2(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0))':
     dependencies:
       '@vitest/spy': 4.0.8
@@ -9555,7 +9927,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.8(@types/node@24.10.1)(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.2.0(bufferutil@4.0.9))(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0)
+      vitest: 4.0.8(@types/debug@4.1.12)(@types/node@25.2.0)(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.2.0(bufferutil@4.0.9))(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0)
 
   '@vitest/utils@4.0.16':
     dependencies:
@@ -9809,6 +10181,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   bare-events@2.8.2:
@@ -9913,6 +10287,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  boolbase@1.0.0: {}
+
   boolean@3.2.0:
     optional: true
 
@@ -9991,6 +10367,8 @@ snapshots:
 
   caniuse-lite@1.0.30001762: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.1: {}
 
   chai@6.2.2: {}
@@ -10005,6 +10383,14 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chardet@2.1.1: {}
 
@@ -10075,6 +10461,8 @@ snapshots:
   clsx@2.1.1: {}
 
   code-block-writer@10.1.1: {}
+
+  collapse-white-space@2.1.0: {}
 
   color-convert@1.9.3:
     dependencies:
@@ -10169,13 +10557,25 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
   css-tree@3.1.0:
     dependencies:
       mdn-data: 2.12.2
       source-map-js: 1.2.1
     optional: true
 
+  css-what@6.2.2: {}
+
   cssesc@3.0.0: {}
+
+  cssom@0.5.0: {}
 
   cssstyle@5.3.7:
     dependencies:
@@ -10245,6 +10645,10 @@ snapshots:
   decimal.js@10.6.0:
     optional: true
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
@@ -10284,6 +10688,8 @@ snapshots:
 
   deprecation@2.3.1: {}
 
+  dequal@2.0.3: {}
+
   destroy@1.2.0: {}
 
   detect-indent@6.1.0: {}
@@ -10292,6 +10698,10 @@ snapshots:
 
   detect-node@2.1.0:
     optional: true
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   devtools-protocol@0.0.1312386:
     optional: true
@@ -10330,6 +10740,12 @@ snapshots:
       domhandler: 4.3.1
       entities: 2.2.0
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
   domelementtype@1.3.1: {}
 
   domelementtype@2.3.0: {}
@@ -10339,6 +10755,10 @@ snapshots:
       domelementtype: 1.3.1
 
   domhandler@4.3.1:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
 
@@ -10352,6 +10772,12 @@ snapshots:
       dom-serializer: 1.4.1
       domelementtype: 2.3.0
       domhandler: 4.3.1
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dotenv@16.6.1: {}
 
@@ -10412,8 +10838,12 @@ snapshots:
 
   entities@3.0.1: {}
 
+  entities@4.5.0: {}
+
   entities@6.0.1:
     optional: true
+
+  entities@7.0.1: {}
 
   env-paths@2.2.1: {}
 
@@ -10615,6 +11045,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   escodegen@2.1.0:
     dependencies:
       esprima: 4.0.1
@@ -10772,6 +11204,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
+  estree-util-visit@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 3.0.3
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -10779,6 +11218,8 @@ snapshots:
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
+
+  eval-estree-expression@3.0.1: {}
 
   event-target-shim@5.0.1: {}
 
@@ -10925,6 +11366,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fault@2.0.1:
+    dependencies:
+      format: 0.2.2
+
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
@@ -11035,6 +11480,8 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+
+  format@0.2.2: {}
 
   formdata-node@4.4.1:
     dependencies:
@@ -11320,6 +11767,15 @@ snapshots:
       whatwg-encoding: 3.1.1
     optional: true
 
+  html-escaper@3.0.3: {}
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   htmlparser2@3.10.1:
     dependencies:
       domelementtype: 1.3.1
@@ -11427,6 +11883,8 @@ snapshots:
 
   ini@1.3.8: {}
 
+  inline-style-parser@0.2.7: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -11436,6 +11894,13 @@ snapshots:
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -11481,6 +11946,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-decimal@2.0.1: {}
+
   is-docker@2.2.1: {}
 
   is-extglob@2.1.1: {}
@@ -11503,6 +11970,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hexadecimal@2.0.1: {}
+
   is-json@2.0.1: {}
 
   is-map@2.0.3: {}
@@ -11515,6 +11984,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1:
     optional: true
@@ -11810,6 +12281,14 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.31.1
       lightningcss-win32-x64-msvc: 1.31.1
 
+  linkedom@0.18.12:
+    dependencies:
+      css-select: 5.2.2
+      cssom: 0.5.0
+      html-escaper: 3.0.3
+      htmlparser2: 10.1.0
+      uhyphen: 0.2.0
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -11827,6 +12306,8 @@ snapshots:
   lodash.startcase@4.4.0: {}
 
   lodash@4.17.21: {}
+
+  longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -11854,6 +12335,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
   marked@17.0.1: {}
 
   marky@1.3.0:
@@ -11865,6 +12348,168 @@ snapshots:
     optional: true
 
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-frontmatter@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      escape-string-regexp: 5.0.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-frontmatter: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx@3.0.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
 
   mdn-data@2.12.2:
     optional: true
@@ -11882,6 +12527,277 @@ snapshots:
   methods@1.1.2: {}
 
   metric-lcs@0.1.2: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-frontmatter@2.0.0:
+    dependencies:
+      fault: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-expression@3.0.1:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-jsx@3.0.2:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-extension-mdx-md@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-extension-mdxjs@3.0.0:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      micromark-extension-mdx-expression: 3.0.1
+      micromark-extension-mdx-jsx: 3.0.2
+      micromark-extension-mdx-md: 2.0.0
+      micromark-extension-mdxjs-esm: 3.0.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-mdx-expression@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-events-to-acorn@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.12
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -12009,6 +12925,10 @@ snapshots:
   normalize-url@6.1.0: {}
 
   npm-normalize-package-bin@1.0.1: {}
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
 
   object-assign@4.1.1: {}
 
@@ -12220,6 +13140,16 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
 
   parse5@8.0.0:
     dependencies:
@@ -12574,6 +13504,57 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  remark-frontmatter@5.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-frontmatter: 2.0.1
+      micromark-extension-frontmatter: 2.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-mdx@3.1.1:
+    dependencies:
+      mdast-util-mdx: 3.0.0
+      micromark-extension-mdxjs: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
+  remark@15.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -12724,6 +13705,27 @@ snapshots:
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
+
+  safe-mdx@1.3.9(react@19.2.3):
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      '@standard-schema/spec': 1.1.0
+      collapse-white-space: 2.1.0
+      eval-estree-expression: 3.0.1
+      linkedom: 0.18.12
+      react: 19.2.3
+      remark: 15.0.1
+      remark-frontmatter: 5.0.0
+      remark-gfm: 4.0.1
+      remark-mdx: 3.1.1
+      style-to-object: 1.0.14
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      unist-util-visit-parents: 6.0.2
+    transitivePeerDependencies:
+      - canvas
+      - supports-color
 
   safe-push-apply@1.0.0:
     dependencies:
@@ -13088,6 +14090,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -13103,6 +14110,10 @@ snapshots:
   strip-json-comments@5.0.3: {}
 
   strnum@2.1.2: {}
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   sumchecker@3.0.1:
     dependencies:
@@ -13234,6 +14245,8 @@ snapshots:
 
   treeify@1.1.0: {}
 
+  trough@2.2.0: {}
+
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -13324,6 +14337,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  uhyphen@0.2.0: {}
+
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -13348,6 +14363,39 @@ snapshots:
       '@fastify/busboy': 2.1.1
 
   unicorn-magic@0.1.0: {}
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position-from-estree@2.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   universal-user-agent@6.0.1: {}
 
@@ -13392,6 +14440,16 @@ snapshots:
       spdx-expression-parse: 3.0.1
 
   vary@1.1.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite-node@3.2.4(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0):
     dependencies:
@@ -13548,7 +14606,7 @@ snapshots:
       tsx: 4.20.6
       yaml: 2.6.0
 
-  vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(@vitest/ui@4.0.8(vitest@4.0.8))(jiti@2.6.1)(jsdom@27.2.0(bufferutil@4.0.9))(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0):
+  vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.2.0(bufferutil@4.0.9))(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0):
     dependencies:
       '@vitest/expect': 4.0.16
       '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0))
@@ -13588,10 +14646,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.8(@types/node@24.10.1)(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.2.0(bufferutil@4.0.9))(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0):
+  vitest@4.0.8(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.2.0(bufferutil@4.0.9))(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0):
     dependencies:
       '@vitest/expect': 4.0.8
-      '@vitest/mocker': 4.0.8(vite@7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0))
+      '@vitest/mocker': 4.0.8(vite@7.2.2(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0))
       '@vitest/pretty-format': 4.0.8
       '@vitest/runner': 4.0.8
       '@vitest/snapshot': 4.0.8
@@ -13611,6 +14669,7 @@ snapshots:
       vite: 7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/debug': 4.1.12
       '@types/node': 24.10.1
       '@vitest/ui': 4.0.8(vitest@4.0.8)
       jsdom: 27.2.0(bufferutil@4.0.9)
@@ -13628,7 +14687,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.8(@types/node@25.2.0)(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.2.0(bufferutil@4.0.9))(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0):
+  vitest@4.0.8(@types/debug@4.1.12)(@types/node@25.2.0)(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.2.0(bufferutil@4.0.9))(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0):
     dependencies:
       '@vitest/expect': 4.0.8
       '@vitest/mocker': 4.0.8(vite@7.2.2(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0))
@@ -13651,6 +14710,7 @@ snapshots:
       vite: 7.2.2(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.6.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/debug': 4.1.12
       '@types/node': 25.2.0
       '@vitest/ui': 4.0.8(vitest@4.0.8)
       jsdom: 27.2.0(bufferutil@4.0.9)
@@ -13866,3 +14926,5 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
       react: 19.2.3
+
+  zwitch@2.0.4: {}

--- a/website/package.json
+++ b/website/package.json
@@ -27,6 +27,7 @@
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-router": "^7.11.0",
+    "safe-mdx": "^1.3.9",
     "sentries": "^0.2.2",
     "string-dedent": "^3.0.2",
     "tailwind-merge": "^3.4.0",

--- a/website/src/routes/markdown.tsx
+++ b/website/src/routes/markdown.tsx
@@ -1,0 +1,454 @@
+/*
+ * Markdown-driven editorial page — same content and styles as _index.tsx,
+ * but rendered from a markdown string via safe-mdx with component overrides.
+ *
+ * Demonstrates that the editorial design system works with markdown content
+ * by mapping safe-mdx's HTML elements to our custom editorial components.
+ */
+
+import type { MetaFunction } from 'react-router'
+import { SafeMdxRenderer } from 'safe-mdx'
+import type { MyRootContent } from 'safe-mdx'
+import { mdxParse } from 'safe-mdx/parse'
+import {
+  EditorialPage,
+  P,
+  A,
+  Code,
+  Caption,
+  CodeBlock,
+  Section,
+  ComparisonTable,
+  List,
+  OL,
+  Li,
+  PixelatedImage,
+  SectionHeading,
+} from 'website/src/components/markdown'
+import placeholderScreenshot from '../assets/placeholders/placeholder-screenshot@2x.png'
+
+export const meta: MetaFunction = () => {
+  const title = 'Playwriter (Markdown) - Chrome extension & CLI that lets agents use your real browser'
+  const description =
+    'Chrome extension and CLI that let your agents control your actual browser. Your logins, extensions, cookies — already there. No headless instance, no bot detection.'
+  const image = 'https://playwriter.dev/og-image.png'
+  return [
+    { title },
+    { name: 'description', content: description },
+    { property: 'og:title', content: title },
+    { property: 'og:description', content: description },
+    { property: 'og:image', content: image },
+    { property: 'og:image:width', content: '1200' },
+    { property: 'og:image:height', content: '630' },
+    { property: 'og:type', content: 'website' },
+    { property: 'og:url', content: 'https://playwriter.dev/markdown' },
+    { name: 'twitter:card', content: 'summary_large_image' },
+    { name: 'twitter:title', content: title },
+    { name: 'twitter:description', content: description },
+    { name: 'twitter:image', content: image },
+  ]
+}
+
+const tocItems = [
+  { label: 'Getting started', href: '#getting-started' },
+  { label: 'How it works', href: '#how-it-works' },
+  { label: 'Collaboration', href: '#collaboration' },
+  { label: 'Snapshots', href: '#snapshots' },
+  { label: 'Visual labels', href: '#visual-labels' },
+  { label: 'Sessions', href: '#sessions' },
+  { label: 'Debugger & editor', href: '#debugger-and-editor' },
+  { label: 'Network interception', href: '#network-interception' },
+  { label: 'Screen recording', href: '#screen-recording' },
+  { label: 'Comparison', href: '#comparison' },
+  { label: 'Remote access', href: '#remote-access' },
+  { label: 'Security', href: '#security' },
+]
+
+/* =========================================================================
+   Markdown content — same text as _index.tsx but in markdown format.
+   Sections use custom <Section> components referenced via safe-mdx.
+   ========================================================================= */
+
+const markdown = `
+A Chrome extension and CLI that let your agents control **your actual browser** \u2014 with logins, extensions, and cookies already there. No headless instance, no bot detection, no extra memory. [Star on GitHub](https://github.com/remorses/playwriter).
+
+<Screenshot />
+
+<Caption>Your existing Chrome session. Extensions, logins, cookies \u2014 all there.</Caption>
+
+Other browser MCPs either **spawn a fresh Chrome** or give agents a fixed set of tools. New Chrome means no logins, no extensions, instant bot detection, and double the memory. Fixed tools mean the agent can't profile performance, can't set breakpoints, can't intercept network requests \u2014 it can only do what someone decided to expose.
+
+Playwriter gives agents the **full Playwright API** through a single \`execute\` tool. One tool, any Playwright code, no wrappers. Low context usage because there's no schema bloat from dozens of tool definitions. And it runs in your existing browser, so **nothing extra gets spawned**.
+
+<Section id="getting-started" title="Getting started">
+
+**Four steps** and your agent is browsing.
+
+1. Install the [Chrome extension](https://chromewebstore.google.com/detail/playwriter-mcp/jfeammnjpkecdekppnclgkkffahnhfhe)
+2. Click the extension icon on a tab \u2014 it turns green
+3. Install the CLI:
+
+\`\`\`bash
+npm i -g playwriter
+\`\`\`
+
+Then install the **skill** \u2014 it teaches your agent how to use Playwriter: which selectors to use, how to avoid timeouts, how to read snapshots, and all available utilities.
+
+\`\`\`bash
+npx -y skills add remorses/playwriter
+\`\`\`
+
+The extension connects your browser to a **local WebSocket relay** on \`localhost:19988\`. The CLI sends Playwright code through the relay. No remote servers, no accounts, nothing leaves your machine.
+
+\`\`\`bash
+playwriter session new              # new sandbox, outputs id (e.g. 1)
+playwriter -e "page.goto('https://example.com')"
+playwriter -e "snapshot({ page })"
+playwriter -e "page.locator('aria-ref=e5').click()"
+\`\`\`
+
+<Caption>Extension icon green = connected. Gray = not attached to this tab.</Caption>
+
+</Section>
+
+<Section id="how-it-works" title="How it works">
+
+Click the extension icon on a tab \u2014 it attaches via \`chrome.debugger\` and opens a WebSocket to a local relay. Your agent (CLI, MCP, or a Playwright script) connects to the same relay. **CDP commands flow through**; the extension forwards them to Chrome and sends responses back. No Chrome restart, no flags, no special setup.
+
+\`\`\`diagram
+\u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510     \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510     \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510
+\u2502   BROWSER           \u2502     \u2502   LOCALHOST          \u2502     \u2502   CLIENT        \u2502
+\u2502                     \u2502     \u2502                      \u2502     \u2502                 \u2502
+\u2502  \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510  \u2502     \u2502 WebSocket Server     \u2502     \u2502  \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510  \u2502
+\u2502  \u2502   Extension   \u2502<\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500>  :19988          \u2502     \u2502  \u2502 CLI / MCP \u2502  \u2502
+\u2502  \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518  \u2502 WS  \u2502                      \u2502     \u2502  \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518  \u2502
+\u2502          \u2502          \u2502     \u2502  /extension          \u2502     \u2502        \u2502        \u2502
+\u2502    chrome.debugger  \u2502     \u2502       \u2502              \u2502     \u2502        v        \u2502
+\u2502          v          \u2502     \u2502       v              \u2502     \u2502  \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510 \u2502
+\u2502  \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510  \u2502     \u2502  /cdp/:id <\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500>\u2502  \u2502 execute    \u2502 \u2502
+\u2502  \u2502 Tab 1 (green) \u2502  \u2502     \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518  WS \u2502  \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518 \u2502
+\u2502  \u2502 Tab 2 (green) \u2502  \u2502                                  \u2502        \u2502        \u2502
+\u2502  \u2502 Tab 3 (gray)  \u2502  \u2502     Tab 3 not controlled         \u2502 Playwright API  \u2502
+\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518     (extension not clicked)      \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518
+\`\`\`
+
+The relay **multiplexes sessions**, so multiple agents or CLI instances can work with the same browser at the same time.
+
+</Section>
+
+<Section id="collaboration" title="Collaboration">
+
+Because the agent works in **your browser**, you can collaborate. You see everything it does in real time. When it hits a captcha, **you solve it**. When a consent wall appears, you click through it. When the agent gets stuck, you disable the extension on that tab, fix things manually, re-enable it, and the agent picks up where it left off.
+
+You're not watching a remote screen or reading logs after the fact. You're **sharing a browser** \u2014 the agent does the repetitive work, you step in when it needs a human.
+
+</Section>
+
+<Section id="snapshots" title="Accessibility snapshots">
+
+Your agent needs to **see the page** before it can act. Accessibility snapshots return every interactive element as text, with Playwright locators attached. **5\u201320KB instead of 100KB+** for a screenshot \u2014 cheaper, faster, and the agent can parse them without vision.
+
+\`\`\`bash
+playwriter -e "snapshot({ page })"
+
+# Output:
+# - banner:
+#     - link "Home" [id="nav-home"]
+#     - navigation:
+#         - link "Docs" [data-testid="docs-link"]
+#         - link "Blog" role=link[name="Blog"]
+\`\`\`
+
+Each line ends with a **locator** you can pass directly to \`page.locator()\`. Subsequent calls return a **diff**, so you only see what changed. Use \`search\` to filter large pages.
+
+\`\`\`bash
+# Search for specific elements
+playwriter -e "snapshot({ page, search: /button|submit/i })"
+
+# Always print URL first, then snapshot \u2014 pages can redirect
+playwriter -e "console.log('URL:', page.url()); snapshot({ page }).then(console.log)"
+\`\`\`
+
+Use snapshots as the **primary way to read pages**. Only reach for screenshots when spatial layout matters \u2014 grids, dashboards, maps.
+
+</Section>
+
+<Section id="visual-labels" title="Visual labels">
+
+When the agent needs to understand **where things are on screen**, \`screenshotWithAccessibilityLabels\` overlays **Vimium-style labels** on every interactive element. The agent sees the screenshot, reads the labels, and clicks by reference.
+
+\`\`\`bash
+playwriter -e "screenshotWithAccessibilityLabels({ page })"
+# Returns screenshot + accessibility snapshot with aria-ref selectors
+
+playwriter -e "page.locator('aria-ref=e5').click()"
+\`\`\`
+
+Labels are **color-coded by element type**: yellow for links, orange for buttons, coral for inputs, pink for checkboxes, peach for sliders, salmon for menus, amber for tabs. The ref system is shared with \`snapshot()\`, so you can switch between text and visual modes freely.
+
+<Caption>Vimium-style labels. Screenshot + snapshot in one call.</Caption>
+
+</Section>
+
+<Section id="sessions" title="Sessions">
+
+Run **multiple agents at once** without them stepping on each other. Each session is an isolated sandbox with its own \`state\` object. Variables, pages, and listeners persist between calls. Browser tabs are shared, but state is not.
+
+\`\`\`bash
+playwriter session new    # => 1
+playwriter session new    # => 2
+playwriter session list   # shows sessions + state keys
+
+# Session 1 stores data
+playwriter -s 1 -e "state.users = page.$$eval('.user', els => els.map(e => e.textContent))"
+
+# Session 2 can't see it
+playwriter -s 2 -e "console.log(state.users)"  # undefined
+\`\`\`
+
+Create your own page to **avoid interference** from other agents. Reuse an existing \`about:blank\` tab or create a fresh one, and store it in \`state\`.
+
+\`\`\`bash
+playwriter -s 1 -e "state.myPage = context.pages().find(p => p.url() === 'about:blank') ?? context.newPage(); state.myPage.goto('https://example.com')"
+
+# All subsequent calls use state.myPage
+playwriter -s 1 -e "state.myPage.title()"
+\`\`\`
+
+</Section>
+
+<Section id="debugger-and-editor" title="Debugger & editor">
+
+Things no other browser MCP can do. **Set breakpoints**, step through code, inspect variables at runtime. **Live-edit page scripts and CSS** without reloading. Full Chrome DevTools Protocol access, not a watered-down subset.
+
+\`\`\`bash
+# Set breakpoints and debug
+playwriter -e "state.cdp = getCDPSession({ page }); state.dbg = createDebugger({ cdp: state.cdp }); state.dbg.enable()"
+playwriter -e "state.scripts = state.dbg.listScripts({ search: 'app' }); state.scripts.map(s => s.url)"
+playwriter -e "state.dbg.setBreakpoint({ file: state.scripts[0].url, line: 42 })"
+
+# Live edit page code
+playwriter -e "state.editor = createEditor({ cdp: state.cdp }); state.editor.enable()"
+playwriter -e "state.editor.edit({ url: 'https://example.com/app.js', oldString: 'const DEBUG = false', newString: 'const DEBUG = true' })"
+\`\`\`
+
+Edits are **in-memory** and persist until the page reloads. Useful for toggling debug flags, patching broken code, or testing quick fixes without touching source files. The editor also supports \`grep\` across all loaded scripts.
+
+<Caption>Breakpoints, stepping, variable inspection \u2014 from the CLI.</Caption>
+
+</Section>
+
+<Section id="network-interception" title="Network interception">
+
+Let the agent **watch network traffic** to reverse-engineer APIs, scrape data behind JavaScript rendering, or debug failing requests. Captured data lives in \`state\` and persists across calls.
+
+\`\`\`bash
+# Start intercepting
+playwriter -e "state.responses = []; page.on('response', async res => { if (res.url().includes('/api/')) { try { state.responses.push({ url: res.url(), status: res.status(), body: await res.json() }); } catch {} } })"
+
+# Trigger actions, then analyze
+playwriter -e "page.click('button.load-more')"
+playwriter -e "console.log('Captured', state.responses.length, 'API calls'); state.responses.forEach(r => console.log(r.status, r.url.slice(0, 80)))"
+
+# Replay an API call directly
+playwriter -e "page.evaluate(async (url) => { const res = await fetch(url); return res.json(); }, state.responses[0].url)"
+\`\`\`
+
+**Faster than scraping the DOM.** The agent captures the real API calls, inspects their schemas, and replays them with different parameters. Works for pagination, authenticated endpoints, and anything behind client-side rendering.
+
+</Section>
+
+<Section id="screen-recording" title="Screen recording">
+
+Have the agent **record what it's doing** as MP4 video. The recording uses \`chrome.tabCapture\` and runs in the extension context, so it **survives page navigation**.
+
+\`\`\`bash
+# Start recording
+playwriter -e "startRecording({ page, outputPath: './recording.mp4', frameRate: 30 })"
+
+# Navigate, interact \u2014 recording continues
+playwriter -e "page.click('a'); page.waitForLoadState('domcontentloaded')"
+playwriter -e "page.goBack()"
+
+# Stop and save
+playwriter -e "stopRecording({ page })"
+\`\`\`
+
+Unlike \`getDisplayMedia\`, this approach **persists across navigations** because the extension holds the \`MediaRecorder\`, not the page. You can also check recording status with \`isRecording\` or cancel without saving with \`cancelRecording\`.
+
+<Caption>Native tab capture. 30\u201360fps. Survives navigation.</Caption>
+
+</Section>
+
+<Section id="comparison" title="Comparison">
+
+Why use this over the alternatives.
+
+<ComparisonTable
+  title="vs Playwright MCP"
+  headers={["", "Playwright MCP", "Playwriter"]}
+  rows={[
+    ["Browser", "Spawns new Chrome", "Uses your Chrome"],
+    ["Extensions", "None", "Your existing ones"],
+    ["Login state", "Fresh", "Already logged in"],
+    ["Bot detection", "Always detected", "Can bypass"],
+    ["Collaboration", "Separate window", "Same browser as user"]
+  ]}
+/>
+
+<ComparisonTable
+  title="vs Playwright CLI"
+  headers={["", "Playwright CLI", "Playwriter"]}
+  rows={[
+    ["Browser", "Spawns new browser", "Uses your Chrome"],
+    ["Login state", "Fresh", "Already logged in"],
+    ["Extensions", "None", "Your existing ones"],
+    ["Captchas", "Always blocked", "Bypass (disconnect extension)"],
+    ["Collaboration", "Separate window", "Same browser as user"],
+    ["Capabilities", "Limited command set", "Anything Playwright can do"],
+    ["Raw CDP access", "No", "Yes"],
+    ["Video recording", "File-based tracing", "Native tab capture (30\u201360fps)"]
+  ]}
+/>
+
+<ComparisonTable
+  title="vs BrowserMCP"
+  headers={["", "BrowserMCP", "Playwriter"]}
+  rows={[
+    ["Tools", "12+ dedicated tools", "1 execute tool"],
+    ["API", "Limited actions", "Full Playwright"],
+    ["Context usage", "High (tool schemas)", "Low"],
+    ["LLM knowledge", "Must learn tools", "Already knows Playwright"]
+  ]}
+/>
+
+<ComparisonTable
+  title="vs Claude Browser Extension"
+  headers={["", "Claude Extension", "Playwriter"]}
+  rows={[
+    ["Agent support", "Claude only", "Any MCP client"],
+    ["Windows WSL", "No", "Yes"],
+    ["Context method", "Screenshots (100KB+)", "A11y snapshots (5\u201320KB)"],
+    ["Playwright API", "No", "Full"],
+    ["Debugger", "No", "Yes"],
+    ["Live code editing", "No", "Yes"],
+    ["Network interception", "Limited", "Full"],
+    ["Raw CDP access", "No", "Yes"]
+  ]}
+/>
+
+</Section>
+
+<Section id="remote-access" title="Remote access">
+
+Control Chrome on a **remote machine** \u2014 a headless Mac mini, a cloud VM, a devcontainer. A [traforo](https://traforo.dev) tunnel exposes the relay through Cloudflare. **No VPN, no firewall rules, no port forwarding.**
+
+\`\`\`bash
+# On the host machine \u2014 start relay with tunnel
+npx -y traforo -p 19988 -t my-machine -- npx -y playwriter serve --token <secret>
+
+# From anywhere \u2014 set env vars and use normally
+export PLAYWRITER_HOST=https://my-machine-tunnel.traforo.dev
+export PLAYWRITER_TOKEN=<secret>
+playwriter -e "page.goto('https://example.com')"
+\`\`\`
+
+Also works on a **LAN without tunnels** \u2014 just set \`PLAYWRITER_HOST=192.168.1.10\`. Works for MCP too \u2014 set \`PLAYWRITER_HOST\` and \`PLAYWRITER_TOKEN\` in your MCP client env config. Use cases: headless Mac mini, remote user support, multi-machine automation, dev from a VM or devcontainer.
+
+</Section>
+
+<Section id="security" title="Security">
+
+Everything runs **on your machine**. The relay binds to \`localhost:19988\` and only accepts connections from the extension. No remote server, no account, no telemetry.
+
+- **Local only** \u2014 WebSocket server binds to localhost. Nothing leaves your machine.
+- **Origin validation** \u2014 only the Playwriter extension origin is accepted. Browsers cannot spoof the Origin header, so malicious websites cannot connect.
+- **Explicit consent** \u2014 only tabs where you clicked the extension icon are controlled. No background access.
+- **Visible automation** \u2014 Chrome shows an automation banner on controlled tabs.
+
+</Section>
+`
+
+/* =========================================================================
+   Component overrides — map safe-mdx HTML elements to editorial components.
+   Custom MDX components (Section, Caption, etc.) are passed directly.
+   ========================================================================= */
+
+const components = {
+  p: ({ children }: { children: React.ReactNode }) => {
+    return <P>{children}</P>
+  },
+  a: ({ href, children }: { href: string; children: React.ReactNode }) => {
+    return <A href={href}>{children}</A>
+  },
+  strong: ({ children }: { children: React.ReactNode }) => {
+    return <strong>{children}</strong>
+  },
+  em: ({ children }: { children: React.ReactNode }) => {
+    return <em>{children}</em>
+  },
+  code: ({ children }: { children: React.ReactNode }) => {
+    return <Code>{children}</Code>
+  },
+  ol: ({ children }: { children: React.ReactNode }) => {
+    return <OL>{children}</OL>
+  },
+  ul: ({ children }: { children: React.ReactNode }) => {
+    return <List>{children}</List>
+  },
+  li: ({ children }: { children: React.ReactNode }) => {
+    return <Li>{children}</Li>
+  },
+  hr: () => {
+    return (
+      <div style={{ padding: '24px 0', display: 'flex', alignItems: 'center' }}>
+        <div style={{ height: '1px', background: 'var(--divider)', flex: 1 }} />
+      </div>
+    )
+  },
+
+  /* Custom MDX components used in the markdown content */
+  Section,
+  Caption,
+  ComparisonTable,
+  Screenshot: () => {
+    return (
+      <div className='bleed' style={{ display: 'flex', justifyContent: 'center' }}>
+        <PixelatedImage
+          src='/screenshot@2x.png'
+          placeholder={placeholderScreenshot}
+          alt='Playwriter controlling Chrome with accessibility labels overlay'
+          width={1280}
+          height={800}
+          style={{ display: 'block', maxWidth: '100%', height: 'auto' }}
+        />
+      </div>
+    )
+  },
+}
+
+/* renderNode handles fenced code blocks — safe-mdx gives us the raw mdast
+   node with lang/meta, which we need to pass to our CodeBlock component. */
+const renderNode = (node: MyRootContent, transform: (n: MyRootContent) => React.ReactNode) => {
+  if (node.type === 'code') {
+    const lang = node.lang || 'bash'
+    const value = node.value || ''
+    const isDiagram = lang === 'diagram'
+    return (
+      <CodeBlock lang={lang} lineHeight={isDiagram ? '1.3' : '1.85'} showLineNumbers={!isDiagram}>
+        {value}
+      </CodeBlock>
+    )
+  }
+  return undefined
+}
+
+const mdast = mdxParse(markdown)
+
+export default function MarkdownPage() {
+  return (
+    <EditorialPage toc={tocItems} logo='playwriter'>
+      <SafeMdxRenderer markdown={markdown} mdast={mdast} components={components} renderNode={renderNode} />
+    </EditorialPage>
+  )
+}


### PR DESCRIPTION
Sessions can now specify a custom Chrome tab group name and color via `playwriter session new --name myproject --color red`. Different sessions with different names get separate Chrome tab groups.

**Extension (0.0.74 → 0.0.77)**
- Custom `groupName`/`groupColor` on `TabInfo`, multi-group `syncTabGroup`, retry logic for `tabGroups.update()` race condition
- Fix tab group flapping: only apply group metadata on `Target.createTarget`, not every CDP command
- `tabsBeingMoved` guard prevents programmatic ungroup from triggering disconnects

**Playwriter MCP/CLI (0.0.85 → 0.0.87)**
- `--name` and `--color` options on `session new`
- Group metadata flows: CLI → relay HTTP → CDP URL params → relay state → extension
- Only inject group fields on `Target.createTarget` to prevent flapping

**Website**
- New `markdown.tsx` route with safe-mdx

Backward compatible — older extensions ignore new fields, omitting options keeps default "playwriter" green group.