### PR TITLE
ci: add npm publish workflow on `playwriter@*` tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,11 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           submodules: true
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
@@ -21,7 +21,7 @@ jobs:
           version: 9
           run_install: false
       - name: Install pnpm dependencies (with cache)
-        uses: covbot/pnpm-install-with-cache@v1
+        uses: covbot/pnpm-install-with-cache@995fcd44de7b93326e513102c66f72c741e19a8c # v1.0.1
       # scripts
       # - run: pnpm build
       # - run: pnpm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,14 +13,14 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           submodules: true
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
## ci: add npm publish workflow on `playwriter@*` tags

Closes #68

### Problem

The Chrome extension bakes in the `playwriterVersion` from `playwriter/package.json` at build time. When the extension is published before the corresponding CLI version reaches npm, users get stuck in a loop:

```
Playwriter 0.0.80 is outdated (extension requires 0.0.85).
Run `npm install -g playwriter@latest` or update the playwriter package in your project.
```

Running `npm install -g playwriter@latest` installs 0.0.80 (the latest on npm), which doesn't satisfy the requirement. This is a recurrence of #67.

### Solution

Add a GitHub Actions workflow that **automatically publishes the `playwriter` package to npm** whenever a tag matching `playwriter@*` is pushed (e.g. `playwriter@0.0.88`).

This ensures the CLI is available on npm before or shortly after the extension goes live.

### What's included

- **New workflow** `.github/workflows/publish.yml` — triggered on `playwriter@*` tag push
- **SHA-pinned actions** in both `ci.yml` and `publish.yml` via [actions-up](https://github.com/azat-io/actions-up) for supply-chain security

### Setup required

The repository needs an `NPM_TOKEN` secret with publish access to the `playwriter` package on npm.

### Note on current state

This workflow prevents future recurrence. The current gap (npm has 0.0.80, extension requires 0.0.85) still needs a **manual `pnpm publish`** or tagging `playwriter@0.0.88` once this workflow is merged and the secret is configured.
