### PR TITLE
fix: pass token to remote status checks

### DIFF
--- a/.changeset/fix-remote-status-token.md
+++ b/.changeset/fix-remote-status-token.md
@@ -1,0 +1,7 @@
+---
+'playwriter': patch
+---
+
+Pass the configured token when remote clients check extension status.
+
+Fixes #85

--- a/playwriter/src/cli-auth.test.ts
+++ b/playwriter/src/cli-auth.test.ts
@@ -1,0 +1,178 @@
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
+import path from 'node:path'
+import { execFile } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+import { afterEach, describe, expect, test } from 'vitest'
+
+const execFileAsync = promisify(execFile)
+const currentDir = path.dirname(fileURLToPath(import.meta.url))
+const playwriterDir = path.resolve(currentDir, '..')
+const viteNodeBinary = path.join(
+  playwriterDir,
+  'node_modules',
+  '.bin',
+  process.platform === 'win32' ? 'vite-node.cmd' : 'vite-node',
+)
+
+const servers: http.Server[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    servers.map((server) => {
+      return new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error)
+            return
+          }
+          resolve()
+        })
+      })
+    }),
+  )
+  servers.length = 0
+})
+
+type CapturedRequest = {
+  method: string | undefined
+  url: string | undefined
+  authorization: string | undefined
+  body?: unknown
+}
+
+function respondJson(res: http.ServerResponse, status: number, body: unknown) {
+  res.writeHead(status, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify(body))
+}
+
+async function readJson(req: http.IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = []
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+  return JSON.parse(Buffer.concat(chunks).toString('utf-8'))
+}
+
+async function createRelayFixture(
+  handler: (req: http.IncomingMessage, res: http.ServerResponse, captured: CapturedRequest) => Promise<void> | void,
+): Promise<{ url: string; requests: CapturedRequest[] }> {
+  const requests: CapturedRequest[] = []
+  const server = http.createServer(async (req, res) => {
+    const captured: CapturedRequest = {
+      method: req.method,
+      url: req.url,
+      authorization: req.headers.authorization,
+    }
+    requests.push(captured)
+    try {
+      await handler(req, res, captured)
+    } catch (error: any) {
+      respondJson(res, 500, { error: error.message })
+    }
+  })
+  servers.push(server)
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve()
+    })
+  })
+
+  const { port } = server.address() as AddressInfo
+  return { url: `http://127.0.0.1:${port}`, requests }
+}
+
+async function runCli(args: string[], env: Record<string, string | undefined> = {}) {
+  return execFileAsync(viteNodeBinary, ['src/cli.ts', ...args], {
+    cwd: playwriterDir,
+    env: {
+      ...process.env,
+      PLAYWRITER_HOST: '',
+      PLAYWRITER_TOKEN: '',
+      ...env,
+    },
+  })
+}
+
+describe('playwriter cli remote auth', () => {
+  test('sends --token while discovering remote extensions for session creation', async () => {
+    const relay = await createRelayFixture(async (req, res, captured) => {
+      if (req.method === 'GET' && req.url === '/extensions/status') {
+        respondJson(res, 200, {
+          extensions: [
+            {
+              extensionId: 'ext-1',
+              stableKey: 'stable-ext-1',
+              browser: 'Chrome',
+              profile: { email: 'user@example.com', id: 'Profile 1' },
+              activeTargets: 1,
+              playwriterVersion: null,
+            },
+          ],
+        })
+        return
+      }
+
+      if (req.method === 'POST' && req.url === '/cli/session/new') {
+        captured.body = await readJson(req)
+        respondJson(res, 200, { id: 'remote-1', extensionId: 'stable-ext-1' })
+        return
+      }
+
+      respondJson(res, 404, { error: 'not found' })
+    })
+
+    const { stdout, stderr } = await runCli(['session', 'new', '--host', relay.url, '--token', 'secret-token'])
+
+    expect(stderr).toBe('')
+    expect(stdout).toContain('Session remote-1 created.')
+    expect(relay.requests.map((request) => request.authorization)).toEqual([
+      'Bearer secret-token',
+      'Bearer secret-token',
+    ])
+    expect(relay.requests[1].body).toMatchObject({ extensionId: 'stable-ext-1' })
+  }, 30000)
+
+  test('sends PLAYWRITER_TOKEN when falling back to legacy extension status', async () => {
+    const relay = await createRelayFixture(async (req, res, captured) => {
+      if (req.method === 'GET' && req.url === '/extensions/status') {
+        respondJson(res, 404, { error: 'not found' })
+        return
+      }
+
+      if (req.method === 'GET' && req.url === '/extension/status') {
+        respondJson(res, 200, {
+          connected: true,
+          browser: 'Chrome',
+          profile: { email: 'user@example.com', id: 'Profile 1' },
+          activeTargets: 1,
+          playwriterVersion: null,
+        })
+        return
+      }
+
+      if (req.method === 'POST' && req.url === '/cli/session/new') {
+        captured.body = await readJson(req)
+        respondJson(res, 200, { id: 'remote-2', extensionId: null })
+        return
+      }
+
+      respondJson(res, 404, { error: 'not found' })
+    })
+
+    const { stdout, stderr } = await runCli(['session', 'new', '--host', relay.url], {
+      PLAYWRITER_TOKEN: 'env-token',
+    })
+
+    expect(stderr).toBe('')
+    expect(stdout).toContain('Session remote-2 created.')
+    expect(relay.requests.map((request) => request.authorization)).toEqual([
+      'Bearer env-token',
+      'Bearer env-token',
+      'Bearer env-token',
+    ])
+    expect(relay.requests[2].body).toMatchObject({ extensionId: null })
+  }, 30000)
+})

--- a/playwriter/src/cli.ts
+++ b/playwriter/src/cli.ts
@@ -169,14 +169,17 @@ function buildAuthHeaders({ token, json }: { token?: string; json?: boolean }): 
   return headers
 }
 
-async function fetchExtensionsStatus(host?: string): Promise<ExtensionStatus[]> {
+async function fetchExtensionsStatus(host?: string, token?: string): Promise<ExtensionStatus[]> {
   try {
     const serverUrl = await getServerUrl(host)
+    const headers = buildAuthHeaders({ token })
     const response = await fetch(`${serverUrl}/extensions/status`, {
+      headers,
       signal: AbortSignal.timeout(2000),
     })
     if (!response.ok) {
       const fallback = await fetch(`${serverUrl}/extension/status`, {
+        headers,
         signal: AbortSignal.timeout(2000),
       })
       if (!fallback.ok) {
@@ -458,7 +461,7 @@ cli
         })
       }
     } else {
-      extensions = await fetchExtensionsStatus(options.host)
+      extensions = await fetchExtensionsStatus(options.host, options.token)
     }
 
     if (extensions.length === 0) {
@@ -929,7 +932,7 @@ cli
     const [extensions, directInstances] = await Promise.all([
       isLocal
         ? waitForConnectedExtensions({ timeoutMs: 2000, pollIntervalMs: 200, logger: console })
-        : fetchExtensionsStatus(options.host),
+        : fetchExtensionsStatus(options.host, options.token),
       isLocal ? discoverChromeInstances() : Promise.resolve([] as DiscoveredInstance[]),
     ])
 

--- a/playwriter/src/executor.ts
+++ b/playwriter/src/executor.ts
@@ -568,6 +568,11 @@ export class PlaywrightExecutor {
     })
   }
 
+  private relayAuthHeaders(): Record<string, string> {
+    const token = this.cdpConfig.token || process.env.PLAYWRITER_TOKEN
+    return token ? { Authorization: `Bearer ${token}` } : {}
+  }
+
   private async checkExtensionStatus(): Promise<{
     connected: boolean
     activeTargets: number
@@ -576,13 +581,16 @@ export class PlaywrightExecutor {
     const { host = '127.0.0.1', port = 19988, extensionId } = this.cdpConfig
     const { httpBaseUrl } = parseRelayHost(host, port)
     const notConnected = { connected: false, activeTargets: 0, playwriterVersion: null }
+    const headers = this.relayAuthHeaders()
     try {
       if (extensionId) {
         const response = await fetch(`${httpBaseUrl}/extensions/status`, {
+          headers,
           signal: AbortSignal.timeout(2000),
         })
         if (!response.ok) {
           const fallback = await fetch(`${httpBaseUrl}/extension/status`, {
+            headers,
             signal: AbortSignal.timeout(2000),
           })
           if (!fallback.ok) {
@@ -616,6 +624,7 @@ export class PlaywrightExecutor {
       }
 
       const response = await fetch(`${httpBaseUrl}/extension/status`, {
+        headers,
         signal: AbortSignal.timeout(2000),
       })
       if (!response.ok) {

--- a/playwriter/src/executor.unit.test.ts
+++ b/playwriter/src/executor.unit.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest'
-import { shouldAutoReturn, wrapCode, isPlaywrightChannelOwner } from './executor.js'
+import { afterEach, describe, it, expect, vi } from 'vitest'
+import { shouldAutoReturn, wrapCode, isPlaywrightChannelOwner, PlaywrightExecutor } from './executor.js'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 describe('shouldAutoReturn', () => {
   it('returns true for simple expressions', () => {
@@ -164,5 +168,32 @@ describe('isPlaywrightChannelOwner', () => {
     expect(isPlaywrightChannelOwner({ _type: 'x', _guid: 'y' })).toBe(false)
     // _type must be a string
     expect(isPlaywrightChannelOwner({ _type: 123, _guid: 'y', _connection: {} })).toBe(false)
+  })
+})
+
+describe('PlaywrightExecutor relay auth', () => {
+  it('sends the relay token while checking extension status', async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ connected: true, activeTargets: 1, playwriterVersion: null }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const executor = new PlaywrightExecutor({
+      cdpConfig: { host: 'relay.example.test', port: 19988, token: 'secret-token' },
+      logger: { log: () => {}, error: () => {} },
+    })
+
+    const status = await (executor as any).checkExtensionStatus()
+
+    expect(status).toMatchObject({ connected: true, activeTargets: 1 })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://relay.example.test:19988/extension/status',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer secret-token' },
+      }),
+    )
   })
 })


### PR DESCRIPTION
Summary:
- Sends the configured bearer token when remote CLI browser discovery calls `/extensions/status` and `/extension/status`.
- Uses the token for executor extension-status checks before connecting through a remote relay.
- Fixes #85.

Testing:
- `pnpm --filter playwriter exec vitest run -u src/cli-auth.test.ts src/executor.unit.test.ts`
- `pnpm --filter playwriter typecheck`
- `pnpm --filter playwriter build`
- `pnpm exec prettier --check playwriter/src/cli-auth.test.ts .changeset/fix-remote-status-token.md`
- `pnpm test` (fails locally because the required @xmorse Playwright Chromium build v1209 is not installed in this cache)