### PR TITLE
Add CDP proxy route for cloud browsers

### DIFF
--- a/.changeset/add-cloud-cdp-proxy.md
+++ b/.changeset/add-cloud-cdp-proxy.md
@@ -1,0 +1,14 @@
+---
+'playwriter': minor
+---
+
+Add support for connecting cloud browser sessions through the Playwriter CDP WebSocket proxy.
+
+Cloud sessions can now use a `wss://playwriter.dev/cdp/...` endpoint so the Browser Use CDP URL stays behind the Playwriter website worker. The CLI builds proxy URLs for new cloud browsers and for reconnecting to existing cloud sessions, while the local relay treats them like normal direct CDP endpoints.
+
+```bash
+playwriter session new --browser cloud
+playwriter session new --browser cloud --proxy us
+```
+
+The existing `/api/cloud/connect` and direct Browser Use connection path remain available, including the fallback path used for custom proxy configuration.

--- a/playwriter/src/cdp-relay.ts
+++ b/playwriter/src/cdp-relay.ts
@@ -2035,8 +2035,11 @@ export async function startPlayWriterCDPRelayServer({
       })
       const metadata = executor.getSessionMetadata()
 
-      // Register cloud session tracking if cloud metadata was provided
-      if (body.cloud) {
+      // Register cloud session tracking only when full cloud metadata is provided
+      // (cloudSessionId + cloudBaseUrl + cloudToken). The CDP proxy path sends
+      // cloud: { blockProxyResources } without these fields, meaning the proxy
+      // handles VM lifecycle — no relay-side tracking needed.
+      if (body.cloud?.cloudSessionId && body.cloud.cloudBaseUrl && body.cloud.cloudToken) {
         cloudSessionTracking.set(sessionId, {
           cloudSessionId: body.cloud.cloudSessionId,
           cloudBaseUrl: body.cloud.cloudBaseUrl,

--- a/playwriter/src/cli.ts
+++ b/playwriter/src/cli.ts
@@ -872,7 +872,9 @@ function parseCloudTimeout(value: string | undefined): number | undefined {
   return timeout
 }
 
-/** Connect to a cloud browser and create a playwriter session via the relay. */
+/** Connect to a cloud browser and create a playwriter session via the relay.
+ *  Uses the CDP proxy at playwriter.dev/cdp/new — the proxy handles VM creation,
+ *  billing, and quota enforcement. The relay just connects to a WSS URL. */
 async function createCloudSession({
   serverUrl,
   proxyRegion,
@@ -895,6 +897,57 @@ async function createCloudSession({
     throw new Error('Not logged in to cloud. Run `playwriter cloud login` first.')
   }
 
+  // Custom proxy requires the old HTTP API path since it has structured params
+  if (customProxy) {
+    return createCloudSessionViaApi({ client, serverUrl, proxyRegion, customProxy, timeout, blockProxyResources, token })
+  }
+
+  // Build the CDP proxy WSS URL. The proxy at playwriter.dev creates the BU VM
+  // on WebSocket connect, so no separate HTTP call is needed.
+  const cdpEndpoint = client.getCdpProxyUrl({ proxyRegion, timeout })
+
+  const cwd = process.cwd()
+  const response = await fetch(`${serverUrl}/cli/session/new`, {
+    method: 'POST',
+    headers: buildAuthHeaders({ token, json: true }),
+    body: JSON.stringify({
+      cdpEndpoint,
+      cwd,
+      browser: 'Chromium (cloud)',
+      cloud: { blockProxyResources },
+    }),
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`${response.status} ${text}`)
+  }
+  const result = (await response.json()) as { id: string }
+
+  // liveUrl is not available via the proxy path (VM info isn't returned).
+  // Users can check `playwriter cloud status` for the live view URL.
+  return { id: result.id, liveUrl: null }
+}
+
+/** Fallback for custom proxy: uses the old HTTP API path since custom proxy
+ *  has structured params that can't be encoded in a query string. */
+async function createCloudSessionViaApi({
+  client,
+  serverUrl,
+  proxyRegion,
+  customProxy,
+  timeout,
+  blockProxyResources,
+  token,
+}: {
+  client: CloudClient
+  serverUrl: string
+  proxyRegion?: string
+  customProxy?: string
+  timeout?: number
+  blockProxyResources?: boolean
+  token?: string
+}): Promise<{ id: string; liveUrl: string | null }> {
   const connectResult = await client.connect({
     proxyRegion,
     customProxy: customProxy ? parseCustomProxy(customProxy) : undefined,
@@ -905,11 +958,7 @@ async function createCloudSession({
     throw new Error('Cloud browser returned no CDP URL. The VM may have failed to start.')
   }
 
-  // Normalize https:// CDP URL to wss:// for the relay
   const cdpEndpoint = await resolveDirectInput(connectResult.cdpUrl)
-
-  // Create a playwriter session via the relay using the CDP URL (same as --direct).
-  // Also pass cloud metadata so the relay can track idle timeout and auto-disconnect.
   const auth = loadCloudAuth()!
   const cwd = process.cwd()
   let response: Response
@@ -931,7 +980,6 @@ async function createCloudSession({
       }),
     })
   } catch (cause) {
-    // Relay session creation failed — stop the cloud VM so we don't leak a paid resource
     await client.disconnect(connectResult.cloudSessionId).catch(() => {})
     throw new Error('Failed to create relay session', { cause })
   }
@@ -947,7 +995,7 @@ async function createCloudSession({
 }
 
 /** Reattach to an existing running cloud browser VM instead of creating a new one.
- *  Fetches the session's cdpUrl from the cloud API and creates a relay session. */
+ *  Uses the CDP proxy reconnect URL to avoid direct BU connection. */
 async function attachExistingCloudSession({
   serverUrl,
   cloudSessionId,
@@ -964,16 +1012,8 @@ async function attachExistingCloudSession({
     throw new Error('Not logged in to cloud. Run `playwriter cloud login` first.')
   }
 
-  const session = await client.getSessionStatus(cloudSessionId)
-  if (!session || session.status !== 'active') {
-    throw new Error('Cloud session is no longer active. It may have timed out.')
-  }
-  if (!session.cdpUrl) {
-    throw new Error('Cloud session has no CDP URL available.')
-  }
-
-  const cdpEndpoint = await resolveDirectInput(session.cdpUrl)
-  const auth = loadCloudAuth()!
+  // Use the CDP proxy reconnect URL. The proxy resolves the BU cdpUrl on connect.
+  const cdpEndpoint = client.getCdpReconnectUrl(cloudSessionId)
   const cwd = process.cwd()
 
   const response = await fetch(`${serverUrl}/cli/session/new`, {
@@ -983,13 +1023,7 @@ async function attachExistingCloudSession({
       cdpEndpoint,
       cwd,
       browser: 'Chromium (cloud)',
-      cloud: {
-        cloudSessionId,
-        cloudBaseUrl: auth.baseUrl,
-        cloudToken: auth.token,
-        timeoutAt: session.timeoutAt,
-        blockProxyResources,
-      },
+      cloud: { blockProxyResources },
     }),
   })
 
@@ -999,7 +1033,8 @@ async function attachExistingCloudSession({
   }
   const result = (await response.json()) as { id: string }
 
-  return { id: result.id, liveUrl: session.liveUrl }
+  // liveUrl not available via proxy path; use `playwriter cloud status` instead
+  return { id: result.id, liveUrl: null }
 }
 
 function printBrowserTable(options: BrowserOption[]): void {

--- a/playwriter/src/cloud-client.ts
+++ b/playwriter/src/cloud-client.ts
@@ -151,6 +151,34 @@ export class CloudClient {
       return s.cloudSessionId === cloudSessionId
     }) ?? null
   }
+
+  /** Build a CDP proxy WebSocket URL for auto-creating a new cloud browser.
+   *  The URL includes auth token so the proxy can authenticate the upgrade.
+   *  No HTTP call is made; the VM is created lazily on WebSocket connect. */
+  getCdpProxyUrl(options?: {
+    proxyRegion?: string
+    timeout?: number
+  }): string {
+    const url = new URL('/cdp/new', this.baseUrl)
+    url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+    url.searchParams.set('token', this.token)
+    if (options?.timeout) {
+      url.searchParams.set('timeout', String(options.timeout))
+    }
+    if (options?.proxyRegion) {
+      url.searchParams.set('proxy', options.proxyRegion)
+    }
+    return url.toString()
+  }
+
+  /** Build a CDP proxy WebSocket URL for reconnecting to an existing session.
+   *  No HTTP call is made; the proxy resolves the BU cdpUrl on connect. */
+  getCdpReconnectUrl(cloudSessionId: string): string {
+    const url = new URL(`/cdp/${cloudSessionId}`, this.baseUrl)
+    url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+    url.searchParams.set('token', this.token)
+    return url.toString()
+  }
 }
 
 /** Create a CloudClient from saved auth, or null if not logged in. */

--- a/website/src/cdp-proxy.ts
+++ b/website/src/cdp-proxy.ts
@@ -1,0 +1,266 @@
+// WebSocket proxy for CDP connections to cloud browsers.
+//
+// Routes:
+//   wss://playwriter.dev/cdp/new?timeout=60&proxy=us   — auto-create VM + proxy
+//   wss://playwriter.dev/cdp/{cloudSessionId}           — reconnect to existing VM
+//
+// Auth: token query param (?token=xxx) or Authorization header.
+// The proxy relays CDP messages bidirectionally between the client (Playwright)
+// and the Browser Use VM. All billing, quota, and VM lifecycle is handled here;
+// the relay/CLI just treats it as a regular CDP endpoint.
+//
+// On client disconnect the BU VM stays alive (it has its own timeout).
+// The existing cron job handles budget enforcement and dead session cleanup.
+
+import * as orm from 'drizzle-orm'
+import * as schema from 'db/schema'
+import { getDb, getSessionWithApiKey, ensureOrg } from './db.ts'
+import {
+  getBrowserUse,
+  validateCloudAccess,
+  createCloudBrowserVM,
+} from './cloud-helpers.ts'
+
+// ── Auth helper ─────────────────────────────────────────────────────
+
+/** Authenticate a WebSocket upgrade request.
+ *  Accepts token from query param or Authorization/x-api-key headers.
+ *  Returns org info on success, or a Response error to send back. */
+async function authenticateWsRequest(request: Request): Promise<
+  | { ok: true; orgId: string }
+  | { ok: false; response: Response }
+> {
+  const url = new URL(request.url)
+  const tokenParam = url.searchParams.get('token')
+
+  // Build a synthetic headers object that includes the token from query param
+  // so we can reuse the existing auth infrastructure (better-auth session resolution)
+  const headers = new Headers(request.headers)
+  if (tokenParam && !headers.has('authorization') && !headers.has('x-api-key')) {
+    // Try as bearer token first; if it starts with pw_ prefix, use x-api-key
+    if (tokenParam.startsWith('pw_')) {
+      headers.set('x-api-key', tokenParam)
+    } else {
+      headers.set('authorization', `Bearer ${tokenParam}`)
+    }
+  }
+
+  const session = await getSessionWithApiKey({ headers })
+  if (!session) {
+    return {
+      ok: false,
+      response: new Response(JSON.stringify({ error: 'unauthorized' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    }
+  }
+
+  const org = await ensureOrg(session.userId, session.user.name)
+  return { ok: true, orgId: org.id }
+}
+
+// ── Outbound WS to BU ──────────────────────────────────────────────
+
+/** Open an outbound WebSocket to a Browser Use CDP URL.
+ *  BU returns https:// CDP URLs; we convert to wss:// for the WebSocket. */
+async function connectToBrowserUse(cdpUrl: string): Promise<
+  | { ok: true; socket: WebSocket }
+  | { ok: false; response: Response }
+> {
+  // Normalize https:// to wss://
+  let wsUrl = cdpUrl
+  if (wsUrl.startsWith('https://')) {
+    wsUrl = 'wss://' + wsUrl.slice('https://'.length)
+  } else if (wsUrl.startsWith('http://')) {
+    wsUrl = 'ws://' + wsUrl.slice('http://'.length)
+  }
+
+  try {
+    const buResponse = await fetch(wsUrl, {
+      headers: { Upgrade: 'websocket' },
+    })
+
+    const buSocket = buResponse.webSocket
+    if (!buSocket) {
+      return {
+        ok: false,
+        response: new Response(
+          JSON.stringify({ error: 'Failed to establish WebSocket to cloud browser' }),
+          { status: 502, headers: { 'Content-Type': 'application/json' } },
+        ),
+      }
+    }
+    buSocket.accept()
+    return { ok: true, socket: buSocket }
+  } catch (cause) {
+    return {
+      ok: false,
+      response: new Response(
+        JSON.stringify({ error: 'Failed to connect to cloud browser CDP endpoint' }),
+        { status: 502, headers: { 'Content-Type': 'application/json' } },
+      ),
+    }
+  }
+}
+
+// ── WebSocket relay ─────────────────────────────────────────────────
+
+/** Wire up bidirectional message relay between server-side and BU WebSockets.
+ *  `serverSocket` is the server end of the WebSocketPair (we listen on it).
+ *  `clientSocket` is the client end (returned in the 101 Response to the caller).
+ *  Returns the Response with status 101 to complete the upgrade. */
+function createRelay({
+  clientSocket,
+  serverSocket,
+  buSocket,
+}: {
+  clientSocket: WebSocket
+  serverSocket: WebSocket
+  buSocket: WebSocket
+}): Response {
+  // Client (via serverSocket) → BU
+  serverSocket.addEventListener('message', (event) => {
+    try {
+      buSocket.send(event.data)
+    } catch {
+      try { serverSocket.close(1001, 'upstream closed') } catch { /* already closed */ }
+    }
+  })
+
+  // BU → Client (via serverSocket)
+  buSocket.addEventListener('message', (event) => {
+    try {
+      serverSocket.send(event.data)
+    } catch {
+      try { buSocket.close(1001, 'client closed') } catch { /* already closed */ }
+    }
+  })
+
+  // Handle close propagation
+  serverSocket.addEventListener('close', () => {
+    try { buSocket.close(1000, 'client disconnected') } catch { /* already closed */ }
+  })
+  buSocket.addEventListener('close', () => {
+    try { serverSocket.close(1000, 'upstream disconnected') } catch { /* already closed */ }
+  })
+
+  // Handle errors
+  serverSocket.addEventListener('error', () => {
+    try { buSocket.close(1011, 'client error') } catch { /* already closed */ }
+  })
+  buSocket.addEventListener('error', () => {
+    try { serverSocket.close(1011, 'upstream error') } catch { /* already closed */ }
+  })
+
+  // Return the client end to the HTTP response — this is what the caller receives
+  return new Response(null, { status: 101, webSocket: clientSocket })
+}
+
+// ── Route handlers ──────────────────────────────────────────────────
+
+/** Handle wss://playwriter.dev/cdp/new — auto-create a BU VM and proxy CDP. */
+async function handleCdpNew(request: Request): Promise<Response> {
+  const auth = await authenticateWsRequest(request)
+  if (!auth.ok) return auth.response
+
+  const url = new URL(request.url)
+  const timeout = (() => {
+    const raw = url.searchParams.get('timeout')
+    if (!raw) return undefined
+    const n = parseInt(raw, 10)
+    if (Number.isNaN(n) || n < 1 || n > 240) return undefined
+    return n
+  })()
+  const proxyRegion = url.searchParams.get('proxy') || undefined
+
+  // Validate subscription, quota, budget (throws Response on failure)
+  const { maxSessions } = await validateCloudAccess({ orgId: auth.orgId })
+
+  // Create BU VM (claims slot, creates VM, updates D1)
+  const vm = await createCloudBrowserVM({
+    orgId: auth.orgId,
+    maxSessions,
+    proxyRegion,
+    timeout,
+  })
+
+  // Connect outbound to BU's CDP URL
+  const buConn = await connectToBrowserUse(vm.cdpUrl)
+  if (!buConn.ok) return buConn.response
+
+  // Create client WebSocket pair
+  const [client, server] = Object.values(new WebSocketPair()) as [WebSocket, WebSocket]
+  server.accept()
+
+  return createRelay({ clientSocket: client, serverSocket: server, buSocket: buConn.socket })
+}
+
+/** Handle wss://playwriter.dev/cdp/{cloudSessionId} — reconnect to existing VM. */
+async function handleCdpReconnect(request: Request, cloudSessionId: string): Promise<Response> {
+  const auth = await authenticateWsRequest(request)
+  if (!auth.ok) return auth.response
+
+  const db = getDb()
+  const bu = getBrowserUse()
+
+  // Look up the session and verify ownership
+  const cloudSession = await db.query.cloudSession.findFirst({
+    where: { id: cloudSessionId, orgId: auth.orgId },
+  })
+  if (!cloudSession) {
+    return new Response(
+      JSON.stringify({ error: 'Cloud session not found' }),
+      { status: 404, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  // Get live CDP URL from BU API
+  const vm = await bu.getBrowser(cloudSession.browserUseSessionId)
+  if (vm.status !== 'active' || !vm.cdpUrl) {
+    return new Response(
+      JSON.stringify({ error: 'Cloud browser is no longer active' }),
+      { status: 410, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  // Connect outbound to BU's CDP URL
+  const buConn = await connectToBrowserUse(vm.cdpUrl)
+  if (!buConn.ok) return buConn.response
+
+  // Create client WebSocket pair
+  const [client, server] = Object.values(new WebSocketPair()) as [WebSocket, WebSocket]
+  server.accept()
+
+  return createRelay({ clientSocket: client, serverSocket: server, buSocket: buConn.socket })
+}
+
+// ── Main handler ────────────────────────────────────────────────────
+
+/** Handle CDP proxy WebSocket requests.
+ *  Called from the main fetch handler before Spiceflow routing. */
+export async function handleCdpProxy(request: Request): Promise<Response | null> {
+  const url = new URL(request.url)
+  const pathname = url.pathname
+
+  // Only handle /cdp/* paths with WebSocket upgrade
+  if (!pathname.startsWith('/cdp/')) return null
+  if (request.headers.get('Upgrade') !== 'websocket') {
+    return new Response('Expected WebSocket upgrade', { status: 426 })
+  }
+
+  if (pathname === '/cdp/new') {
+    return handleCdpNew(request)
+  }
+
+  // /cdp/{cloudSessionId}
+  const cloudSessionId = pathname.slice('/cdp/'.length)
+  if (!cloudSessionId) {
+    return new Response(
+      JSON.stringify({ error: 'Missing cloud session ID' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  return handleCdpReconnect(request, cloudSessionId)
+}

--- a/website/src/cloud-api.ts
+++ b/website/src/cloud-api.ts
@@ -3,19 +3,19 @@
 // VM status is queried from Browser Use on demand (source of truth),
 // our D1 only stores the org → BU session ID mapping for multi-tenancy.
 
-import { env } from 'cloudflare:workers'
 import { Spiceflow, json } from 'spiceflow'
 import { z } from 'zod'
-import * as orm from 'drizzle-orm'
-import * as schema from 'db/schema'
 import { getDb, requireOrgSession } from './db.ts'
-import { BrowserUseClient, BrowserUseApiError } from './lib/browser-use.ts'
 import type { BrowserSession } from './lib/browser-use.ts'
-import { ACTIVE_SUBSCRIPTION_STATUSES } from './lib/billing-rules.ts'
-
-function getBrowserUse() {
-  return new BrowserUseClient({ apiKey: env.BROWSER_USE_API_KEY as string })
-}
+import {
+  getBrowserUse,
+  isPendingRow,
+  resolveActiveSession,
+  cleanupDeadSessions,
+  recordFinalCostAndDelete,
+  validateCloudAccess,
+  createCloudBrowserVM,
+} from './cloud-helpers.ts'
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -29,147 +29,6 @@ interface CloudSessionStatus {
   cdpUrl: string | null
   liveUrl: string | null
   timeoutAt: string
-}
-
-// ── Helpers ─────────────────────────────────────────────────────────
-
-const PENDING_PREFIX = 'pending-'
-// Placeholder rows older than 2 minutes are considered stale (VM creation
-// should complete in under 60s). Fresh ones are counted as occupied slots.
-const PENDING_STALE_MS = 2 * 60_000
-
-function isPendingRow(row: typeof schema.cloudSession.$inferSelect): boolean {
-  return row.browserUseSessionId.startsWith(PENDING_PREFIX)
-}
-
-function isUniqueConstraintError(cause: unknown): boolean {
-  const message = cause instanceof Error ? cause.message : String(cause)
-  return message.includes('UNIQUE constraint failed') || message.includes('SQLITE_CONSTRAINT_UNIQUE')
-}
-
-async function claimCloudSessionSlot({
-  orgId,
-  maxSessions,
-}: {
-  orgId: string
-  maxSessions: number
-}): Promise<typeof schema.cloudSession.$inferSelect | null> {
-  const db = getDb()
-  for (let slotIndex = 1; slotIndex <= maxSessions; slotIndex++) {
-    const placeholderId = `${PENDING_PREFIX}${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-    try {
-      const [row] = await db
-        .insert(schema.cloudSession)
-        .values({
-          orgId,
-          slotIndex,
-          browserUseSessionId: placeholderId,
-        })
-        .returning()
-      if (row) return row
-    } catch (cause) {
-      if (isUniqueConstraintError(cause)) {
-        continue
-      }
-      throw new Error('Failed to claim cloud session slot', { cause })
-    }
-  }
-  return null
-}
-
-/** Check if a cloud session row represents an occupied slot.
- *  Returns true if occupied. Does NOT delete stale/dead rows itself;
- *  instead pushes their IDs into deadIds for the caller to batch-delete. */
-function checkSlotOccupied(
-  row: typeof schema.cloudSession.$inferSelect,
-  deadIds: string[],
-): 'occupied' | 'dead' | 'needs-api-check' {
-  if (isPendingRow(row)) {
-    if (Date.now() - row.createdAt < PENDING_STALE_MS) {
-      return 'occupied'
-    }
-    deadIds.push(row.id)
-    return 'dead'
-  }
-  return 'needs-api-check'
-}
-
-/** Parse Browser Use proxyCost string (e.g. "0.05") to integer cents. */
-function parseCostToCents(proxyCost: string): number {
-  const parsed = parseFloat(proxyCost)
-  if (Number.isNaN(parsed)) return 0
-  return Math.round(parsed * 100)
-}
-
-/** Record final proxy cost delta for a session being removed, then delete the row.
- *  Atomically increments org.proxySpendCents by the delta between the session's
- *  lastProxyCostCents baseline and the final BU proxyCost. If no BU session data
- *  is available (e.g. VM already gone), skips the cost update. */
-async function recordFinalCostAndDelete({
-  cloudSession,
-  buSession,
-  orgId,
-}: {
-  cloudSession: typeof schema.cloudSession.$inferSelect
-  buSession: BrowserSession | null
-  orgId: string
-}): Promise<void> {
-  const db = getDb()
-  const finalCostCents = buSession ? parseCostToCents(buSession.proxyCost) : 0
-  const deltaCents = Math.max(0, finalCostCents - cloudSession.lastProxyCostCents)
-
-  if (deltaCents > 0) {
-    // Atomic increment + delete in one batch to avoid partial state
-    await db.batch([
-      db.update(schema.org)
-        .set({
-          proxySpendCents: orm.sql`${schema.org.proxySpendCents} + ${deltaCents}`,
-          updatedAt: Date.now(),
-        })
-        .where(orm.eq(schema.org.id, orgId)),
-      db.delete(schema.cloudSession)
-        .where(orm.eq(schema.cloudSession.id, cloudSession.id)),
-    ])
-  } else {
-    await db.delete(schema.cloudSession)
-      .where(orm.eq(schema.cloudSession.id, cloudSession.id))
-  }
-}
-
-/** Check if a cloud session's BU VM is still alive. Returns null if dead.
- *  On confirmed 404: records final cost and pushes ID into deadIds for cleanup.
- *  On transient errors (500, network): leaves the row for next cron/status retry. */
-async function resolveActiveSession(
-  row: typeof schema.cloudSession.$inferSelect,
-  bu: BrowserUseClient,
-  deadIds: string[],
-): Promise<BrowserSession | null> {
-  try {
-    const vm = await bu.getBrowser(row.browserUseSessionId)
-    if (vm.status === 'active') {
-      return vm
-    }
-    // VM is stopped — record final cost and mark as dead
-    await recordFinalCostAndDelete({ cloudSession: row, buSession: vm, orgId: row.orgId })
-    deadIds.push(row.id)
-    return null
-  } catch (err) {
-    // Only treat confirmed 404 as dead. Transient errors (500, rate limit,
-    // network) leave the row intact so the next check can retry.
-    if (err instanceof BrowserUseApiError && err.status === 404) {
-      deadIds.push(row.id)
-    }
-    return null
-  }
-}
-
-/** Delete dead cloud session rows in one statement. Idempotent: concurrent
- *  requests deleting the same row is safe (DELETE by PK is a no-op if gone). */
-async function cleanupDeadSessions(deadIds: string[]): Promise<void> {
-  if (deadIds.length === 0) return
-  const db = getDb()
-  const uniqueIds = [...new Set(deadIds)]
-  await db.delete(schema.cloudSession).where(orm.inArray(schema.cloudSession.id, uniqueIds))
 }
 
 // ── Sub-app ─────────────────────────────────────────────────────────
@@ -246,153 +105,18 @@ export const cloudApp = new Spiceflow({ basePath: '/api/cloud' })
     async handler({ request }) {
       const { org } = await requireOrgSession(request)
       const body = await request.json()
-      const db = getDb()
-      const bu = getBrowserUse()
 
-      // Batch-read subscription + cloud sessions + org budget in one D1 round-trip.
-      const [activeSub, dbSessions, orgRow] = await db.batch([
-        db.query.subscription.findFirst({
-          where: {
-            orgId: org.id,
-            status: { in: [...ACTIVE_SUBSCRIPTION_STATUSES] },
-          },
-        }),
-        db.query.cloudSession.findMany({
-          where: { orgId: org.id },
-        }),
-        db.query.org.findFirst({
-          where: { id: org.id },
-          columns: { proxySpendCents: true, proxyBudgetCents: true, proxySpendPeriodStart: true },
-        }),
-      ] as const)
-      if (!activeSub) {
-        throw json(
-          { error: 'No active subscription. Run `playwriter cloud subscribe` to get started.' },
-          { status: 403 },
-        )
-      }
-
-      // Detect billing period rollover and reset spend if needed.
-      // This also handles the case where all sessions were killed by the cron
-      // (no active sessions = cron returns early = period never resets).
-      // Without this, the org would be permanently blocked after a period ends.
-      const periodRolledOver = activeSub.currentPeriodStart != null
-        && orgRow?.proxySpendPeriodStart !== activeSub.currentPeriodStart
-      let proxySpendCents = orgRow?.proxySpendCents ?? 0
-      if (periodRolledOver) {
-        proxySpendCents = 0
-        await db.update(schema.org)
-          .set({
-            proxySpendCents: 0,
-            proxySpendPeriodStart: activeSub.currentPeriodStart,
-            updatedAt: Date.now(),
-          })
-          .where(orm.eq(schema.org.id, org.id))
-      }
-
-      // Block new sessions if org exceeded their proxy spend budget
-      if (orgRow && proxySpendCents >= orgRow.proxyBudgetCents) {
-        const spentDollars = (proxySpendCents / 100).toFixed(2)
-        const budgetDollars = (orgRow.proxyBudgetCents / 100).toFixed(2)
-        throw json(
-          { error: `Proxy usage budget exceeded ($${spentDollars}/$${budgetDollars}). Contact support to increase your budget.` },
-          { status: 403 },
-        )
-      }
-
-      const maxSessions = activeSub.quantity
-      // Check each session, collecting dead IDs for batch cleanup.
-      // BU API checks run in parallel; stale pending rows are detected locally.
-      const deadIds: string[] = []
-      let freshPendingCount = 0
-      const buCheckRows: typeof dbSessions = []
-      for (const row of dbSessions) {
-        const status = checkSlotOccupied(row, deadIds)
-        if (status === 'occupied') {
-          freshPendingCount++
-        } else if (status === 'needs-api-check') {
-          buCheckRows.push(row)
-        }
-      }
-      const buResults = await Promise.all(
-        buCheckRows.map((row) => {
-          return resolveActiveSession(row, bu, deadIds)
-        }),
-      )
-      await cleanupDeadSessions(deadIds)
-      const buOccupied = buResults.filter(Boolean).length
-      const activeCount = freshPendingCount + buOccupied
-
-      if (activeCount >= maxSessions) {
-        throw json(
-          {
-            error: `Cloud session limit reached (${activeCount}/${maxSessions}). Stop an existing session or upgrade your subscription quantity.`,
-          },
-          { status: 403 },
-        )
-      }
-
-      // Claim a quota slot before creating the paid VM. The unique index on
-      // (orgId, slotIndex) makes this atomic under concurrent requests: only
-      // one request can own each subscription slot.
-      const cloudSession = await claimCloudSessionSlot({ orgId: org.id, maxSessions })
-      if (!cloudSession) {
-        throw json(
-          { error: `Cloud session limit reached. Stop an existing session or upgrade your subscription quantity.` },
-          { status: 403 },
-        )
-      }
-
-      // Now create the BU VM. If this fails, clean up the placeholder row.
-      let vm: BrowserSession
-      try {
-        vm = await bu.createBrowser({
-          // Proxy disabled by default to save cost. Pass --proxy <region> to enable.
-          proxyCountryCode: body.proxyRegion ?? null,
-          timeout: body.timeout ?? 60,
-          customProxy: body.customProxy,
-        })
-      } catch (cause) {
-        await db
-          .delete(schema.cloudSession)
-          .where(orm.eq(schema.cloudSession.id, cloudSession.id))
-          .limit(1)
-          .catch(() => {})
-        throw new Error('Failed to create cloud browser', { cause })
-      }
-
-      if (!vm.cdpUrl) {
-        // No CDP URL means the VM failed to start. Clean up both.
-        await bu.stopBrowser(vm.id).catch(() => {})
-        await db
-          .delete(schema.cloudSession)
-          .where(orm.eq(schema.cloudSession.id, cloudSession.id))
-          .limit(1)
-          .catch(() => {})
-        throw json(
-          { error: 'Browser Use returned no CDP URL. The VM may have failed to start.' },
-          { status: 502 },
-        )
-      }
-
-      // Update the placeholder with the real BU session ID.
-      // Verify the row still exists (wasn't deleted by a concurrent stale cleanup).
-      const updateResult = await db
-        .update(schema.cloudSession)
-        .set({ browserUseSessionId: vm.id })
-        .where(orm.eq(schema.cloudSession.id, cloudSession.id))
-        .limit(1)
-        .returning()
-
-      if (!updateResult.length) {
-        // Our placeholder was deleted (e.g. by a concurrent stale cleanup).
-        // Stop the VM since our slot is gone.
-        await bu.stopBrowser(vm.id).catch(() => {})
-        throw new Error('Cloud session slot was reclaimed during VM creation')
-      }
+      const { maxSessions } = await validateCloudAccess({ orgId: org.id })
+      const vm = await createCloudBrowserVM({
+        orgId: org.id,
+        maxSessions,
+        proxyRegion: body.proxyRegion,
+        timeout: body.timeout,
+        customProxy: body.customProxy,
+      })
 
       return {
-        cloudSessionId: cloudSession.id,
+        cloudSessionId: vm.cloudSessionId,
         cdpUrl: vm.cdpUrl,
         liveUrl: vm.liveUrl,
         timeoutAt: vm.timeoutAt,

--- a/website/src/cloud-helpers.ts
+++ b/website/src/cloud-helpers.ts
@@ -1,0 +1,336 @@
+// Shared billing, quota, and VM lifecycle helpers for cloud browser sessions.
+// Used by cloud-api.ts (HTTP routes) and cdp-proxy.ts (WebSocket proxy).
+
+import { env } from 'cloudflare:workers'
+import * as orm from 'drizzle-orm'
+import * as schema from 'db/schema'
+import { getDb, type OrgInfo } from './db.ts'
+import { BrowserUseClient, BrowserUseApiError } from './lib/browser-use.ts'
+import type { BrowserSession } from './lib/browser-use.ts'
+import { ACTIVE_SUBSCRIPTION_STATUSES } from './lib/billing-rules.ts'
+
+// ── Constants ───────────────────────────────────────────────────────
+
+export const PENDING_PREFIX = 'pending-'
+/** Placeholder rows older than 2 minutes are considered stale (VM creation
+ *  should complete in under 60s). Fresh ones are counted as occupied slots. */
+export const PENDING_STALE_MS = 2 * 60_000
+
+// ── BU client factory ───────────────────────────────────────────────
+
+export function getBrowserUse() {
+  return new BrowserUseClient({ apiKey: env.BROWSER_USE_API_KEY as string })
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+export function isPendingRow(row: typeof schema.cloudSession.$inferSelect): boolean {
+  return row.browserUseSessionId.startsWith(PENDING_PREFIX)
+}
+
+export function isUniqueConstraintError(cause: unknown): boolean {
+  const message = cause instanceof Error ? cause.message : String(cause)
+  return message.includes('UNIQUE constraint failed') || message.includes('SQLITE_CONSTRAINT_UNIQUE')
+}
+
+/** Parse Browser Use proxyCost string (e.g. "0.05") to integer cents. */
+export function parseCostToCents(proxyCost: string): number {
+  const parsed = parseFloat(proxyCost)
+  if (Number.isNaN(parsed)) return 0
+  return Math.round(parsed * 100)
+}
+
+// ── Slot claiming ───────────────────────────────────────────────────
+
+export async function claimCloudSessionSlot({
+  orgId,
+  maxSessions,
+}: {
+  orgId: string
+  maxSessions: number
+}): Promise<typeof schema.cloudSession.$inferSelect | null> {
+  const db = getDb()
+  for (let slotIndex = 1; slotIndex <= maxSessions; slotIndex++) {
+    const placeholderId = `${PENDING_PREFIX}${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    try {
+      const [row] = await db
+        .insert(schema.cloudSession)
+        .values({
+          orgId,
+          slotIndex,
+          browserUseSessionId: placeholderId,
+        })
+        .returning()
+      if (row) return row
+    } catch (cause) {
+      if (isUniqueConstraintError(cause)) {
+        continue
+      }
+      throw new Error('Failed to claim cloud session slot', { cause })
+    }
+  }
+  return null
+}
+
+// ── Slot occupancy check ────────────────────────────────────────────
+
+/** Check if a cloud session row represents an occupied slot.
+ *  Returns 'occupied' for fresh pending rows, 'dead' for stale ones
+ *  (pushed into deadIds), or 'needs-api-check' for real BU sessions. */
+export function checkSlotOccupied(
+  row: typeof schema.cloudSession.$inferSelect,
+  deadIds: string[],
+): 'occupied' | 'dead' | 'needs-api-check' {
+  if (isPendingRow(row)) {
+    if (Date.now() - row.createdAt < PENDING_STALE_MS) {
+      return 'occupied'
+    }
+    deadIds.push(row.id)
+    return 'dead'
+  }
+  return 'needs-api-check'
+}
+
+// ── BU session resolution ───────────────────────────────────────────
+
+/** Record final proxy cost delta for a session being removed, then delete the row.
+ *  Atomically increments org.proxySpendCents by the delta between the session's
+ *  lastProxyCostCents baseline and the final BU proxyCost. */
+export async function recordFinalCostAndDelete({
+  cloudSession,
+  buSession,
+  orgId,
+}: {
+  cloudSession: typeof schema.cloudSession.$inferSelect
+  buSession: BrowserSession | null
+  orgId: string
+}): Promise<void> {
+  const db = getDb()
+  const finalCostCents = buSession ? parseCostToCents(buSession.proxyCost) : 0
+  const deltaCents = Math.max(0, finalCostCents - cloudSession.lastProxyCostCents)
+
+  if (deltaCents > 0) {
+    await db.batch([
+      db.update(schema.org)
+        .set({
+          proxySpendCents: orm.sql`${schema.org.proxySpendCents} + ${deltaCents}`,
+          updatedAt: Date.now(),
+        })
+        .where(orm.eq(schema.org.id, orgId)),
+      db.delete(schema.cloudSession)
+        .where(orm.eq(schema.cloudSession.id, cloudSession.id)),
+    ])
+  } else {
+    await db.delete(schema.cloudSession)
+      .where(orm.eq(schema.cloudSession.id, cloudSession.id))
+  }
+}
+
+/** Check if a cloud session's BU VM is still alive. Returns null if dead.
+ *  On confirmed 404: records final cost and pushes ID into deadIds.
+ *  On transient errors (500, network): leaves the row for next retry. */
+export async function resolveActiveSession(
+  row: typeof schema.cloudSession.$inferSelect,
+  bu: BrowserUseClient,
+  deadIds: string[],
+): Promise<BrowserSession | null> {
+  try {
+    const vm = await bu.getBrowser(row.browserUseSessionId)
+    if (vm.status === 'active') {
+      return vm
+    }
+    await recordFinalCostAndDelete({ cloudSession: row, buSession: vm, orgId: row.orgId })
+    deadIds.push(row.id)
+    return null
+  } catch (err) {
+    if (err instanceof BrowserUseApiError && err.status === 404) {
+      deadIds.push(row.id)
+    }
+    return null
+  }
+}
+
+/** Delete dead cloud session rows in one statement. */
+export async function cleanupDeadSessions(deadIds: string[]): Promise<void> {
+  if (deadIds.length === 0) return
+  const db = getDb()
+  const uniqueIds = [...new Set(deadIds)]
+  await db.delete(schema.cloudSession).where(orm.inArray(schema.cloudSession.id, uniqueIds))
+}
+
+// ── Subscription & quota validation ─────────────────────────────────
+
+/** Validate that an org can create a new cloud browser session.
+ *  Checks subscription, budget, and quota. Returns maxSessions on success.
+ *  Throws a JSON Response error on failure. */
+export async function validateCloudAccess({ orgId }: { orgId: string }): Promise<{
+  maxSessions: number
+}> {
+  const db = getDb()
+  const bu = getBrowserUse()
+
+  const [activeSub, dbSessions, orgRow] = await db.batch([
+    db.query.subscription.findFirst({
+      where: {
+        orgId,
+        status: { in: [...ACTIVE_SUBSCRIPTION_STATUSES] },
+      },
+    }),
+    db.query.cloudSession.findMany({
+      where: { orgId },
+    }),
+    db.query.org.findFirst({
+      where: { id: orgId },
+      columns: { proxySpendCents: true, proxyBudgetCents: true, proxySpendPeriodStart: true },
+    }),
+  ] as const)
+
+  if (!activeSub) {
+    throw new Response(
+      JSON.stringify({ error: 'No active subscription. Run `playwriter cloud subscribe` to get started.' }),
+      { status: 403, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  // Detect billing period rollover and reset spend if needed
+  const periodRolledOver = activeSub.currentPeriodStart != null
+    && orgRow?.proxySpendPeriodStart !== activeSub.currentPeriodStart
+  let proxySpendCents = orgRow?.proxySpendCents ?? 0
+  if (periodRolledOver) {
+    proxySpendCents = 0
+    await db.update(schema.org)
+      .set({
+        proxySpendCents: 0,
+        proxySpendPeriodStart: activeSub.currentPeriodStart,
+        updatedAt: Date.now(),
+      })
+      .where(orm.eq(schema.org.id, orgId))
+  }
+
+  // Block if org exceeded proxy spend budget
+  if (orgRow && proxySpendCents >= orgRow.proxyBudgetCents) {
+    const spentDollars = (proxySpendCents / 100).toFixed(2)
+    const budgetDollars = (orgRow.proxyBudgetCents / 100).toFixed(2)
+    throw new Response(
+      JSON.stringify({ error: `Proxy usage budget exceeded ($${spentDollars}/$${budgetDollars}). Contact support to increase your budget.` }),
+      { status: 403, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  const maxSessions = activeSub.quantity
+
+  // Count occupied slots: fresh pending + live BU sessions
+  const deadIds: string[] = []
+  let freshPendingCount = 0
+  const buCheckRows: typeof dbSessions = []
+  for (const row of dbSessions) {
+    const status = checkSlotOccupied(row, deadIds)
+    if (status === 'occupied') {
+      freshPendingCount++
+    } else if (status === 'needs-api-check') {
+      buCheckRows.push(row)
+    }
+  }
+  const buResults = await Promise.all(
+    buCheckRows.map((row) => {
+      return resolveActiveSession(row, bu, deadIds)
+    }),
+  )
+  await cleanupDeadSessions(deadIds)
+  const buOccupied = buResults.filter(Boolean).length
+  const activeCount = freshPendingCount + buOccupied
+
+  if (activeCount >= maxSessions) {
+    throw new Response(
+      JSON.stringify({ error: `Cloud session limit reached (${activeCount}/${maxSessions}). Stop an existing session or upgrade your subscription quantity.` }),
+      { status: 403, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  return { maxSessions }
+}
+
+// ── VM creation with slot lifecycle ─────────────────────────────────
+
+/** Claim a slot, create a BU VM, and return the session info.
+ *  Cleans up on failure (deletes placeholder, stops orphaned VM). */
+export async function createCloudBrowserVM({
+  orgId,
+  maxSessions,
+  proxyRegion,
+  timeout,
+  customProxy,
+}: {
+  orgId: string
+  maxSessions: number
+  proxyRegion?: string
+  timeout?: number
+  customProxy?: { host: string; port: number; username?: string; password?: string }
+}): Promise<{
+  cloudSessionId: string
+  browserUseSessionId: string
+  cdpUrl: string
+  liveUrl: string | null
+  timeoutAt: string
+}> {
+  const db = getDb()
+  const bu = getBrowserUse()
+
+  const cloudSession = await claimCloudSessionSlot({ orgId, maxSessions })
+  if (!cloudSession) {
+    throw new Response(
+      JSON.stringify({ error: 'Cloud session limit reached. Stop an existing session or upgrade your subscription quantity.' }),
+      { status: 403, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  let vm: BrowserSession
+  try {
+    vm = await bu.createBrowser({
+      proxyCountryCode: proxyRegion ?? null,
+      timeout: timeout ?? 60,
+      customProxy,
+    })
+  } catch (cause) {
+    await db
+      .delete(schema.cloudSession)
+      .where(orm.eq(schema.cloudSession.id, cloudSession.id))
+      .limit(1)
+      .catch(() => {})
+    throw new Error('Failed to create cloud browser', { cause })
+  }
+
+  if (!vm.cdpUrl) {
+    await bu.stopBrowser(vm.id).catch(() => {})
+    await db
+      .delete(schema.cloudSession)
+      .where(orm.eq(schema.cloudSession.id, cloudSession.id))
+      .limit(1)
+      .catch(() => {})
+    throw new Response(
+      JSON.stringify({ error: 'Browser Use returned no CDP URL. The VM may have failed to start.' }),
+      { status: 502, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  // Update placeholder with real BU session ID
+  const updateResult = await db
+    .update(schema.cloudSession)
+    .set({ browserUseSessionId: vm.id })
+    .where(orm.eq(schema.cloudSession.id, cloudSession.id))
+    .limit(1)
+    .returning()
+
+  if (!updateResult.length) {
+    await bu.stopBrowser(vm.id).catch(() => {})
+    throw new Error('Cloud session slot was reclaimed during VM creation')
+  }
+
+  return {
+    cloudSessionId: cloudSession.id,
+    browserUseSessionId: vm.id,
+    cdpUrl: vm.cdpUrl,
+    liveUrl: vm.liveUrl,
+    timeoutAt: vm.timeoutAt,
+  }
+}

--- a/website/src/server.tsx
+++ b/website/src/server.tsx
@@ -12,6 +12,7 @@ import { app as holocronApp } from '@holocron.so/vite/app'
 import { getAuth, getBaseUrl, getSession, requireSession, ensureOrg, getOrgSubscription, getOrgWithSubscription, listUserApiKeys } from './db.ts'
 import { normalizeAuthRedirectPath } from './auth-redirect.ts'
 import { cloudApp } from './cloud-api.ts'
+import { handleCdpProxy } from './cdp-proxy.ts'
 import { stripeWebhookApp } from './stripe-webhook.ts'
 import { approveDevice, denyDevice, createApiKey, revokeApiKey } from './actions.tsx'
 import { enforceProxyBudgets } from './scheduled.ts'
@@ -279,6 +280,12 @@ declare module 'spiceflow/react' {
 
 export default {
   async fetch(request: Request): Promise<Response> {
+    // Handle CDP WebSocket proxy before Spiceflow routing.
+    // WebSocket upgrades to /cdp/* are intercepted here because Spiceflow
+    // doesn't handle WebSocket protocol upgrades.
+    const cdpResponse = await handleCdpProxy(request)
+    if (cdpResponse) return cdpResponse
+
     return app.handle(request)
   },
   async scheduled(_controller: ScheduledController, _env: Env, ctx: ExecutionContext) {


### PR DESCRIPTION
**What changed**

Add a Cloudflare Worker WebSocket proxy for cloud browser CDP connections:

- `wss://playwriter.dev/cdp/new` creates a Browser Use VM and proxies CDP
- `wss://playwriter.dev/cdp/:cloudSessionId` reconnects to an existing VM
- cloud billing, quota, slot claiming, and VM creation logic is shared between the HTTP API and proxy path
- the CLI now builds proxy CDP URLs for cloud sessions and passes them to the local relay as direct CDP endpoints

**Notes**

The existing `/api/cloud/connect` flow remains available. Custom proxy configuration still uses the old HTTP path because it has structured credentials.

The proxy path currently keeps Browser Use VMs alive when the client disconnects and relies on Browser Use hard timeout plus existing budget cron cleanup.

**Checks**

- `pnpm typecheck` in `website`
- `pnpm typecheck` in `playwriter`
- `lintcn lint` in `website`

`lintcn lint` in `playwriter` still reports existing issues in `cdp-relay.ts` and `mcp.ts`; I did not expand the PR to fix those unrelated lint findings.