### PR TITLE
docs: document extension input focus

### DIFF
--- a/.changeset/document-extension-input-focus.md
+++ b/.changeset/document-extension-input-focus.md
@@ -1,0 +1,7 @@
+---
+'playwriter': patch
+---
+
+Document that extension-mode keyboard input follows Chrome's OS focus and that agents should click a field before filling it.
+
+Fixes #99

--- a/playwriter/src/skill.md
+++ b/playwriter/src/skill.md
@@ -352,6 +352,7 @@ Writing to any other path (e.g. `~/Downloads`, `~/Desktop`) throws `EPERM: opera
 - **Multiple calls**: use multiple execute calls for complex logic - helps understand intermediate state and isolate which action failed
 - **Never close**: never call `browser.close()` or `context.close()`. Only close pages you created or if user asks
 - **No bringToFront**: never call unless user asks - it's disruptive and unnecessary, you can interact with background pages
+- **Click before keyboard input in extension mode.** Call `click()` on the target field immediately before `fill()` or `keyboard` methods. CDP sends keyboard input to the browser's OS-focused surface, so DOM focus and `bringToFront()` can still leave text in Chrome's omnibox.
 - **Check state after actions**: always verify page state after clicking/submitting (see next section)
 - **Clean up listeners**: call `state.page.removeAllListeners()` at end of message to prevent leaks
 - **Always print page logs after every action**: call `getLatestLogs({ page: state.page, sinceLastCall: true })` after every goto, click, or submit to catch console errors and warnings. Do not manually collect `page.on('console')` events; manual listeners miss logs emitted before the listener is attached. The first `sinceLastCall` call returns all buffered logs including startup and hydration errors.


### PR DESCRIPTION
In extension mode, CDP routes keyboard input to whichever Chrome surface has OS focus. This adds a direct agent rule to click the target field before fill() or keyboard methods, preventing text from landing in the omnibox. It also adds the required patch changeset.

Fixes #99

Validated with git diff --check. The new changeset passes Prettier, and the added skill text is unchanged by Prettier.

Prepared with Codex assistance.