### PR TITLE
feat: add PLAYWRITER_EXEC_TIMEOUT env var for default execution timeout

### DIFF
--- a/.changeset/exec-timeout-env-var.md
+++ b/.changeset/exec-timeout-env-var.md
@@ -1,0 +1,14 @@
+---
+'playwriter': patch
+---
+
+Add `PLAYWRITER_EXEC_TIMEOUT` environment variable to set the default execution timeout (ms) for CLI `-e`/`-f` and the MCP `execute` tool.
+
+Explicit `--timeout` (CLI) or `timeout` (MCP tool argument) still overrides the env default. Internal CDP/infrastructure timeouts are unchanged.
+
+```bash
+export PLAYWRITER_EXEC_TIMEOUT=30000
+playwriter -s 1 -e 'await page.goto("https://slow.example")'
+```
+
+Fixes #102

--- a/playwriter/src/cdp-relay.ts
+++ b/playwriter/src/cdp-relay.ts
@@ -1978,11 +1978,13 @@ export async function startPlayWriterCDPRelayServer({
   app.use('/stream/*', privilegedRouteMiddleware)
   app.use('/mcp-log', privilegedRouteMiddleware)
 
+  const DEFAULT_EXEC_TIMEOUT = Number(process.env.PLAYWRITER_EXEC_TIMEOUT) || 10000
+
   app.post('/cli/execute', async (c) => {
     try {
       const body = (await c.req.json()) as { sessionId: string | number; code: string; timeout?: number }
       const sessionId = normalizeSessionId(body.sessionId)
-      const { code, timeout = 10000 } = body
+      const { code, timeout = DEFAULT_EXEC_TIMEOUT } = body
 
       if (!sessionId || !code) {
         return c.json({ error: 'sessionId and code are required' }, 400)

--- a/playwriter/src/cli.ts
+++ b/playwriter/src/cli.ts
@@ -111,15 +111,17 @@ cli
     }
   })
 
+const DEFAULT_EXEC_TIMEOUT = Number(process.env.PLAYWRITER_EXEC_TIMEOUT) || 10000
+
 cli
   .command('', 'Start the MCP server or controls the browser with -e')
-  .option('--host <host>', 'Remote relay server host to connect to (or use PLAYWRITER_HOST env var)')
+  .option('--host <host>', 'Remote relay server to connect to (or use PLAYWRITER_HOST env var)')
   .option('--token <token>', 'Authentication token (or use PLAYWRITER_TOKEN env var)')
   .option('-s, --session <name>', 'Session ID (required for -e, get one with `playwriter session new`)')
   .option('-e, --eval <code>', 'Execute JavaScript code and exit, read https://playwriter.dev/SKILL.md for usage')
   .option('-f, --file <path>', 'Execute JavaScript from a file and exit')
   .option('--patchright', 'Use @playwriter/patchright-core for stealth mode (bypasses bot detection)')
-  .option('--timeout [ms]', z.number().default(10000).describe('Execution timeout in milliseconds'))
+  .option('--timeout [ms]', z.number().default(DEFAULT_EXEC_TIMEOUT).describe('Execution timeout in milliseconds'))
   .action(async (options) => {
     if (options.patchright) {
       process.env.PLAYWRITER_PATCHRIGHT = '1'
@@ -149,7 +151,7 @@ cli
     if (code) {
       await executeCode({
         code,
-        timeout: options.timeout || 10000,
+        timeout: options.timeout || DEFAULT_EXEC_TIMEOUT,
         sessionId: options.session,
         host: options.host,
         token: options.token,

--- a/playwriter/src/cli.ts
+++ b/playwriter/src/cli.ts
@@ -115,7 +115,7 @@ const DEFAULT_EXEC_TIMEOUT = Number(process.env.PLAYWRITER_EXEC_TIMEOUT) || 1000
 
 cli
   .command('', 'Start the MCP server or controls the browser with -e')
-  .option('--host <host>', 'Remote relay server to connect to (or use PLAYWRITER_HOST env var)')
+  .option('--host <host>', 'Remote relay server host to connect to (or use PLAYWRITER_HOST env var)')
   .option('--token <token>', 'Authentication token (or use PLAYWRITER_TOKEN env var)')
   .option('-s, --session <name>', 'Session ID (required for -e, get one with `playwriter session new`)')
   .option('-e, --eval <code>', 'Execute JavaScript code and exit, read https://playwriter.dev/SKILL.md for usage')

--- a/playwriter/src/mcp.ts
+++ b/playwriter/src/mcp.ts
@@ -233,6 +233,8 @@ server.resource(
   },
 )
 
+const DEFAULT_EXEC_TIMEOUT = Number(process.env.PLAYWRITER_EXEC_TIMEOUT) || 10000
+
 server.tool(
   'execute',
   promptContent,
@@ -242,7 +244,10 @@ server.tool(
       .describe(
         'js playwright code, has {page, state, context} in scope. Should be one line, using ; to execute multiple statements. you MUST call execute multiple times instead of writing complex scripts in a single tool call.',
       ),
-    timeout: z.number().default(10000).describe('Timeout in milliseconds for code execution (default: 10000ms)'),
+    timeout: z
+      .number()
+      .default(DEFAULT_EXEC_TIMEOUT)
+      .describe('Timeout in milliseconds for code execution (default: 10000ms, or PLAYWRITER_EXEC_TIMEOUT)'),
   },
   async ({ code, timeout }) => {
     try {

--- a/playwriter/src/skill.md
+++ b/playwriter/src/skill.md
@@ -188,6 +188,19 @@ playwriter -s <sessionId> -e "<code>"
 
 The `-s` flag specifies a session ID (required). Get one with `playwriter session new`. Use the same session to persist state across commands.
 
+**Execution timeout:** default is 10000ms. Override per call with `--timeout <ms>`, or set a new default via env:
+
+```bash
+# One-off longer timeout (e.g. createDemoVideo, slow navigations)
+playwriter -s 1 --timeout 120000 -e '...'
+
+# Default for all -e/-f in this shell
+export PLAYWRITER_EXEC_TIMEOUT=30000
+playwriter -s 1 -e '...'
+```
+
+`PLAYWRITER_EXEC_TIMEOUT` is the fallback default only; an explicit `--timeout` always wins. MCP clients can set the same env var on the server process, or pass `timeout` on each `execute` call.
+
 **Examples:**
 
 ```bash

--- a/playwriter/src/skill.md
+++ b/playwriter/src/skill.md
@@ -191,7 +191,7 @@ The `-s` flag specifies a session ID (required). Get one with `playwriter sessio
 **Execution timeout:** default is 10000ms. Override per call with `--timeout <ms>`, or set a new default via env:
 
 ```bash
-# One-off longer timeout (e.g. createDemoVideo, slow navigations)
+# One-off longer timeout 
 playwriter -s 1 --timeout 120000 -e '...'
 
 # Default for all -e/-f in this shell
@@ -199,8 +199,7 @@ export PLAYWRITER_EXEC_TIMEOUT=30000
 playwriter -s 1 -e '...'
 ```
 
-`PLAYWRITER_EXEC_TIMEOUT` is the fallback default only; an explicit `--timeout` always wins. MCP clients can set the same env var on the server process, or pass `timeout` on each `execute` call.
-
+PLAYWRITER_EXEC_TIMEOUT is the default fallback. --timeout overrides it, and MCP clients can set the env var or pass a per-call timeout.
 **Examples:**
 
 ```bash


### PR DESCRIPTION
## What problems was I solving

Users needed a way to set a default execution timeout for long-running Playwright scripts without passing `--timeout` on every CLI invocation or `timeout` on every MCP `execute` call. This was especially painful for slow navigations, demo video creation, and CI environments where scripts consistently exceeded the 10s default.

## Changes

- [playwriter/src/cli.ts](https://github.com/tylergibbs1/playwriter/feat/timeout-env-var/files#diff-648caa9fc77b4750ae24bccaba0e1814e67fb981d707002946580743bafca5be) - Added `PLAYWRITER_EXEC_TIMEOUT` env var support; CLI `-e`/`-f` now respects this as the default timeout when `--timeout` is omitted
- [playwriter/src/cdp-relay.ts](https://github.com/tylergibbs1/playwriter/feat/timeout-env-var/files#diff-ba3e445476b65f9024c34a6cd5980cdfc6367f40181fdde45a66e47f4f35ab3b) - Relay `/cli/execute` endpoint now uses env var as default when request body omits `timeout`
- [playwriter/src/mcp.ts](https://github.com/tylergibbs1/playwriter/feat/timeout-env-var/files#diff-0f6b88496b28ab3215c61a8bd7d43ac3dbd633363f09b13d3691e8d8b7cc3afe) - MCP `execute` tool schema now uses env var as default; updated describe text to mention the env override
- [playwriter/src/skill.md](https://github.com/tylergibbs1/playwriter/feat/timeout-env-var/files#diff-7ac0abf1c7580e19ee69aaaa69eaaf4be67071e9d0e426240abc241404be9600) - Documented `PLAYWRITER_EXEC_TIMEOUT` and `--timeout` under "Execute code" section
-  [.changeset/exec-timeout-env-var.md](https://github.com/tylergibbs1/playwriter/feat/timeout-env-var/files#diff-fdbaee525b45d38f43b94ffa04bf3917e1ae43640914dbc2a655121674ad34c4) - 
Added patch changeset for public package `playwriter` referencing issue #102

**Note:** CDP infrastructure timeouts (extension polling, tab creation, executor internal timeouts, stream operations) remain hard-coded and are not affected by this env var. Only user-facing execution timeouts are configurable.


## How to verify it

### Manual Testing

**Test 1: Env raises timeout**
```bash
export PLAYWRITER_EXEC_TIMEOUT=30000
tsx playwriter/src/cli.ts session new
tsx playwriter/src/cli.ts -s 1 -e "await new Promise(r => setTimeout(r, 15000)); 'ok'"
```
Expect: `ok` (would fail under 10s default)

**Test 2: Explicit --timeout wins**
```bash
export PLAYWRITER_EXEC_TIMEOUT=30000
tsx playwriter/src/cli.ts -s 1 --timeout 2000 -e "await new Promise(r => setTimeout(r, 5000)); 'ok'"
```
Expect: timeout error ~2s

**Test 3: Unset env = 10s default**
```bash
unset PLAYWRITER_EXEC_TIMEOUT
tsx playwriter/src/cli.ts -s 1 -e "await new Promise(r => setTimeout(r, 15000)); 'ok'"
```
Expect: timeout error ~10s

**Test 4: MCP path (optional)**
Set `PLAYWRITER_EXEC_TIMEOUT=30000` in MCP server env, call `execute` with 15s sleep (no timeout arg) → expect success. Call with `timeout: 2000` and 5s sleep → expect timeout.