### PR TITLE
fix: use Browser Use Cloud V4

### DIFF
--- a/website/src/lib/browser-use.ts
+++ b/website/src/lib/browser-use.ts
@@ -1,9 +1,9 @@
-// Typed client for Browser Use Cloud API v3.
-// API reference: https://docs.browser-use.com/openapi/v3.json
+// Typed client for Browser Use Cloud API v4.
+// API reference: https://docs.browser-use.com/openapi/v4.json
 // Only used server-side in the website Worker. The bu_ API key never leaves
 // this process; CLI and relay only ever see the cdpUrl that comes back.
 
-const BU_BASE = 'https://api.browser-use.com/api/v3'
+const BU_BASE = 'https://api.browser-use.com/api/v4'
 
 /** Typed error from Browser Use API with HTTP status code.
  *  Use `error.status` to distinguish transient failures (500, 429)
@@ -73,11 +73,7 @@ export class BrowserUseClient {
     this.apiKey = apiKey
   }
 
-  private async request<T>(
-    method: string,
-    path: string,
-    body?: Record<string, unknown>,
-  ): Promise<T> {
+  private async request<T>(method: string, path: string, body?: Record<string, unknown>): Promise<T> {
     const url = `${BU_BASE}${path}`
     const headers: Record<string, string> = {
       'X-Browser-Use-API-Key': this.apiKey,


### PR DESCRIPTION
## What

- move Playwriter's managed Browser Use cloud browsers from /api/v3 to /api/v4
- point the typed client at the current V4 OpenAPI reference

## Why

Playwriter's website Worker only uses Browser Use browser endpoints: create, get, stop, and list. That complete contract is supported by V4, so the managed cloud path can use the current API without changing its public behavior.

## Validation

- current V4 OpenAPI checked for all used routes, request fields, response fields, and list filters
- targeted Prettier check
- full website type-check
- full website production build
- git diff check

No credentials or live Browser Use sessions were used.